### PR TITLE
Add color to map attribute choice and unify song difficult choice logic and bug fix

### DIFF
--- a/static/llsong.js
+++ b/static/llsong.js
@@ -57,14 +57,21 @@ function LLSong(songjson, includeDefaultSong) {
    this.songSearchId = 'songsearch';
    this.songDiffId = 'songdiff';
    this.mapAttId = 'map';
+   this.diffSelId = 'diffchoice';
 };
 
+// listeners
 LLSong.prototype.initListeners = function() {
    var me = this;
    var funcOnSongFilterChange = function() { me.onSongFilterChange(); };
+   var funcOnSongSelectChange = function() { me.onSongSelectChange(); };
+   var funcOnDiffSelectChange = function() { me.onDiffSelectChange(); };
    this._listen(this.songAttId, 'change', funcOnSongFilterChange);
    this._listen(this.songUnitId, 'change', funcOnSongFilterChange);
    this._listen(this.songSearchId, 'change', funcOnSongFilterChange);
+   this._listen(this.songDiffId, 'change', funcOnSongFilterChange);
+   this._listen(this.songSelId, 'change', funcOnSongSelectChange);
+   this._listen(this.diffSelId, 'change', funcOnDiffSelectChange);
 };
 LLSong.prototype._listen = function(id, e, func) {
    if (!(id && e && func)) return;
@@ -72,6 +79,8 @@ LLSong.prototype._listen = function(id, e, func) {
    if (!element) return;
    element.addEventListener(e, func);
 };
+
+// gets
 LLSong.prototype.getElementValue = function (id, defaultValue) {
    if (!id) return defaultValue;
    var ret = undefined;
@@ -103,10 +112,21 @@ LLSong.prototype.getSongAttr = function (songindex) {
    if (songattr == "") songattr = this.getElementValue(this.mapAttId, "");
    return songattr;
 };
+
+// event handlers
 LLSong.prototype.defaultOnSongFilterChange = function () {
    this.filterSongs();
+   this.onSongSelectChange();
 };
 LLSong.prototype.onSongFilterChange = LLSong.prototype.defaultOnSongFilterChange;
+LLSong.prototype.defaultOnSongSelectChange = function () {
+   this.filterDiff();
+   this.onDiffSelectChange();
+};
+LLSong.prototype.onSongSelectChange = LLSong.prototype.defaultOnSongSelectChange;
+LLSong.prototype.onDiffSelectChange = function () {};
+
+// filters
 LLSong.prototype.filterSongs = function (songsel, songatt, songunit, songdiff, keyword) {
    // TODO: filter by event(sm, mf, etc.), by star, by special flags (限时, 超难关, 滑键, etc.)
    if (songsel === undefined) songsel = this.getElementOrThrow(this.songSelId);
@@ -151,5 +171,102 @@ LLSong.prototype.filterSongs = function (songsel, songatt, songunit, songdiff, k
 };
 LLSong.prototype.showAllSongs = function (songsel) {
    this.filterSongs(songsel, "", "", "", "");
+};
+LLSong.prototype.filterDiff = function (diffsel, songindex, cnhave, defaultdiff) {
+   if (diffsel === undefined) diffsel = this.getElementOrThrow(this.diffSelId);
+   if (songindex === undefined) songindex = this.getSelectedSongIndex();
+   if (cnhave === undefined) cnhave = '';
+   if (defaultdiff === undefined) defaultdiff = 'expert';
+
+   diffsel.options.length = 0;
+   if (songindex == "") return;
+
+   var savediff = diffsel.value;
+   if (!savediff) savediff = this.getElementValue(this.songDiffId, "");
+   if (!savediff) savediff = defaultdiff;
+
+   var diffname = ['easy', 'normal', 'hard', 'expert', 'master'];
+   var curSong = this.songs[songindex];
+   for (var i in diffname) {
+      var diff = diffname[i];
+      var curSongWithDiff = curSong[diff];
+      if (!curSongWithDiff) continue;
+      if (cnhave == '' || (curSongWithDiff['cnhave'] == cnhave)) {
+         var newOption = new Option(diff, diff);
+         diffsel.options.add(newOption);
+         if (savediff == diff) {
+            diffsel.value = savediff;
+         }
+      }
+   }
+};
+LLSong.prototype.applyDataOfSongWithDiff = function (targets, songindex, diff) {
+   // targets: {
+   //    '<song property>': [
+   //       ['<element id>', '<element property>'], ...
+   //    ], ...
+   // }
+   if (targets === undefined) return;
+   if (songindex === undefined) songindex = this.getSelectedSongIndex();
+   var curSong = this.songs[songindex];
+   if (!curSong) return;
+   if (diff === undefined) diff = this.getElementValue(this.diffSelId, "");
+
+   var songattr = this.getSongAttr(songindex);
+   var songattrcolor = this.attcolor[songattr];
+   for (var songprop in targets) {
+      var value;
+      if (songprop == "attrcolor") {
+         value = songattrcolor;
+      } else if (songprop == "attribute") {
+         value = songattr;
+      } else if (curSong[songprop] !== undefined) {
+         value = curSong[songprop];
+      } else if (curSong[diff] && curSong[diff][songprop] !== undefined) {
+         value = curSong[diff][songprop];
+      } else {
+         console.error("Not found song property '" + songprop + "'");
+         continue;
+      }
+      var elements = targets[songprop];
+      for (var i in elements) {
+         var element = elements[i];
+         if (typeof(element) == "function") {
+            element(value);
+            continue;
+         }
+         if (typeof(element) == "string") element = [element];
+         if (element.length == 0) {
+            console.error("Not found element property data for song property '" + songprop + "'[" + i + "]");
+            continue;
+         }
+         var curObject = document.getElementById(element[0]);
+         if (!curObject) {
+            console.error("Not found element by id '" + element[0] + "'");
+            continue;
+         }
+         if (element.length == 1) {
+            if (songprop == "attrcolor") {
+               curObject.style.color = value;
+            } else {
+               curObject.value = value;
+            }
+         } else {
+            curObject[element[1]] = value;
+         }
+      }
+   }
+};
+
+// utils
+LLSong.prototype.initAttrSelectColor = function (sel) {
+   if (sel === undefined) throw "Not specified select";
+   if (typeof(sel) == "string") sel = this.getElementOrThrow(sel);
+   var len = sel.options.length;
+   for (var i = 0; i < len; i++) {
+      var opt = sel.options[i];
+      opt.style.color = this.attcolor[opt.value];
+   }
+   sel.style.color = this.attcolor[sel.value];
 };
 

--- a/static/llsong.js
+++ b/static/llsong.js
@@ -100,7 +100,7 @@ LLSong.prototype.getSelectedSongIndex = function (selid) {
    return this.getElementValue(selid, "");
 };
 LLSong.prototype.getSelectedSong = function (selid) {
-   return this.songs[getSelectedSongIndex(selid)];
+   return this.songs[this.getSelectedSongIndex(selid)];
 };
 LLSong.prototype.getSongAttr = function (songindex) {
    if (songindex === undefined) songindex = this.getSelectedSongIndex();

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -70,6 +70,14 @@
    
    var skilllevel = 0
 
+   var diffspeed = {
+      'easy': 2,
+      'normal': 4,
+      'hard': 6,
+      'expert': 8,
+      'master': 9
+   };
+
    function threetonumber(three){
       var result = three
       if (result == '0') {
@@ -310,8 +318,8 @@
       var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
+      llsong.onSongFilterChange();
       changecardselect()
-      changesongselect()
       document.getElementById("cardchoice").value = cardchoice
    }
    
@@ -359,67 +367,12 @@
    	changeavatarselect()
    }
 
-   function changesongselect(){
-      llsong.filterSongs();
-      changesonginfo("songchoice")
-   }
-   
-   function changediffinfo(){
-      savediff = document.getElementById('diffchoice').value
-      index = document.getElementById('songchoice').value
-      diffc = document.getElementById('songdiff').value
-      //smnum =document.getElementById("smfilter").value
-      //mfnum =document.getElementById("mffilter").value
-
-      diffsel = document.getElementById('diffchoice')
-      diffsel.options.length = 0;
-      diffname = ['easy', 'normal', 'hard', 'expert', 'master']
-      finddiff = false
-      //if (index == '')
-      //   return
-      for (i in diffname){
-         diff = diffname[i]
-         if (songs[index][diff] != null){
-            cnhave = ''
-            if (((songs[index][diff]['cnhave'] == cnhave) || (cnhave == '')) && ((diffc == '') || (diff == diffc))) {
-
-                  newOption = new Option(diff, diff)
-                  diffsel.options.add(newOption)
-                  if (savediff == diff){
-                     document.getElementById('diffchoice').value = savediff
-                     finddiff = true
-               }
-            }
-         }
+   function applysongdata() {
+      llsong.applyDataOfSongWithDiff({'attrcolor':['songchoice']});
+      var diff = document.getElementById("diffchoice").value;
+      if (diffspeed[diff]) {
+         document.getElementById("speeds").value = diffspeed[diff];
       }
-      if (!finddiff)
-         document.getElementById('diffchoice').value = 'expert'
-      return 
-   }
-   
-   function changespeeds(){
-        switch (document.getElementById("diffchoice").value)
-        {
-            case "easy":
-                document.getElementById("speeds")[1].selected = true;
-                break;
-            case "normal":
-                document.getElementById("speeds")[3].selected = true;
-                break;
-            case "hard":
-                document.getElementById("speeds")[5].selected = true;
-                break;
-            case "expert":
-                document.getElementById("speeds")[7].selected = true;
-                break;
-            case "master":
-                document.getElementById("speeds")[8].selected = true;
-                break;
-        }
-    }
-   
-   function changesonginfo(which){
-      document.getElementById("songchoice").style.color = llsong.attcolor[llsong.getSongAttr()]
    }
    
    function copyTo(n){
@@ -527,7 +480,9 @@
    		language = 0
    	
       llsong.language = language;
+      llsong.onDiffSelectChange = applysongdata;
       llsong.showAllSongs();
+      llsong.initListeners();
    	getcardselect("", "", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
@@ -559,9 +514,9 @@
             //calslot(i)
 		}
    	}
-   	document.getElementById("songsearch").value = ""
+      document.getElementById("songsearch").value = ""
       // above codes may select songs/cards/filters according to cookies, so refresh it...
-      changesongselect();
+      llsong.onSongFilterChange();
       changecardselect();
    }
    
@@ -590,8 +545,8 @@
 {% block main %}
 <form action="" id="unitform" name="unitform" method="POST" onsubmit="return check()" enctype=multipart/form-data>
 <h3>Live信息</h3>
-搜索：<input type="text" id="songsearch" name="songsearch" value="" onchange="changesongselect()"></input><br>
-筛选：<select id="songdiff" name="songdiff" onchange="changesongselect();changediffinfo();changespeeds()">
+搜索：<input type="text" id="songsearch" name="songsearch" value=""></input><br>
+筛选：<select id="songdiff" name="songdiff">
 		<option value="">难度</option>
 		<option value="easy">包含easy难度</option>
 		<option value="normal">包含normal难度</option>
@@ -599,24 +554,24 @@
 		<option value="expert">包含expert难度</option>
 		<option value="master">包含master难度</option>
 	</select>
-	<select id="songatt" name="songatt" onchange="changesongselect()">
+	<select id="songatt" name="songatt">
 		<option value="">属性</option>
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
 	</select>
-	<select id="songunit" name="songunit" onchange="changesongselect()">
+	<select id="songunit" name="songunit">
 		<option value="">组合</option>
 		<option value="muse">μ's</option>
 		<option value="aqours">Aqours</option>
 	</select>
 <br>
-歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesonginfo('songchoice');changespeeds()">
+歌曲：<select id="songchoice" name="songchoice">
 		<option value=""> </option>
 	</select>
 	<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	<br>
-难度：<select id="diffchoice" name="diffchoice" onchange="changesonginfo('songchoice');changespeeds()">
+难度：<select id="diffchoice" name="diffchoice">
       <option value="easy">easy</option>
       <option value="normal">normal</option>
       <option value="hard">hard</option>

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -318,11 +318,6 @@
    	return false;
    }
    
-   function changesongselect(){
-      llsong.filterSongs();
-      changesongcolor("songchoice")
-   }
-   
    function changecardselect(){
       rarity = document.getElementById("rarity").value
       chr = document.getElementById("chr").value
@@ -370,46 +365,32 @@
    	}
    	changeavatarselect()
    }
-   
-   function changesongcolor(which){
-      var index = llsong.getSelectedSongIndex(which);
-      if (index != "") {
-         var diff = document.getElementById('diffchoice').value;
-         var songattr = llsong.getSongAttr(index);
 
-         var c = attcolor[songattr];
-         document.getElementById(which).style.color = c;
-//         document.getElementById("secondbase").innerHTML = songattr
-         document.getElementById("secondbase2").innerHTML = songattr;
-         selectlist = ["map",  "bonus2"];
-         for (i in selectlist){
-            document.getElementById(selectlist[i]).value = songattr;
-         }
-//   		if (document.getElementById("percentage").value != 12)
-//   			document.getElementById("base").value = songattr
-         if (document.getElementById("percentage2").value != 12)
-            document.getElementById("base2").value = songattr;
-         infolist = ["combo",  "time"]
-         for (i in infolist){
-            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
-         }
-         if (document.getElementById("time").value == ""){
-            document.getElementById("time").value = 110
-         }
-         totalweight = 0
-         for (i = 0; i < 9; i++)
-            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
-         c = parseInt(llsong.songs[index][diff].combo)
-         sl = (totalweight-c)*100/0.25/c
-         //document.getElementById('slider').value = sl.toFixed(1)
-         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-         for (i = 0; i < 9; i++){
-            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
-         }
-      }
+   function changemapcolor(attr) {
+      if (attr === undefined) attr = document.getElementById('map').value;
+      // do not update base, secondbase, bonus, because they are set by center
+      document.getElementById('map').style.color = llsong.attcolor[attr];
+      if (attr == llsong.getSongAttr()) document.getElementById('songchoice').style.color = llsong.attcolor[attr];
+      document.getElementById('secondbase2').innerHTML = attr;
+      if (document.getElementById("percentage2").value != 12) document.getElementById('base2').value = attr;
+      document.getElementById('bonus2').value = attr;
    }
-   
+
+   function applysongdata() {
+      var handleTime = function(t) { document.getElementById("time").value = (t ? t : 110); };
+      var handlePerfect = function(combo) { document.getElementById("perfect").value = parseInt(combo*19/20); };
+      var handleStar = function() { document.getElementById("starperfect").value = 0; };
+      var handleWeight = function(w) { for (var i = 0; i < 9; i++) { document.getElementById("weight"+i).value = parseFloat(w[i]); } };
+      var applyTarget = {
+         'attribute': ['map', changemapcolor],
+         'combo': ['combo', handlePerfect],
+         'time': [handleTime],
+         'star': [handleStar],
+         'positionweight': [handleWeight]
+      };
+      llsong.applyDataOfSongWithDiff(applyTarget);
+   }
+
    function cardidtoindex(n){
    	cardid = parseInt(n)
    	for (i in cards){
@@ -526,8 +507,8 @@
       var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
+      llsong.onSongFilterChange();
       changecardselect()
-      changesongselect()
       document.getElementById("cardchoice").value = cardchoice
    }
    
@@ -679,9 +660,10 @@
    		language = 0
    	
       llsong.language = language;
-      llsong.onSongFilterChange = changesongselect;
+      llsong.onDiffSelectChange = applysongdata;
       llsong.showAllSongs();
       llsong.initListeners();
+      llsong.initAttrSelectColor('map');
    	getcardselect("", "", "", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
@@ -706,38 +688,13 @@
    		changeavatar(i)
          calslot(i)
    	}
-   	document.getElementById("songsearch").value = ""
+      document.getElementById("songsearch").value = ""
       // above codes may select songs/cards/filters according to cookies, so refresh it...
       llsong.onSongFilterChange();
       changecardselect();
 	document.getElementById("submembersoperation").style.display="none"
    }
    
-   function changediffinfo(){
-      savediff = document.getElementById('diffchoice').value
-      index = document.getElementById('songchoice').value
-
-      diffsel = document.getElementById('diffchoice')
-      diffsel.options.length = 0;
-      diffname = ['easy', 'normal', 'hard', 'expert','master']
-      finddiff = false
-      for (i in diffname){
-         diff = diffname[i]
-         if (llsong.songs[index][diff] != null){
-
-                  newOption = new Option(diff, diff)
-                  diffsel.options.add(newOption)
-                  if (savediff == diff){
-                     document.getElementById('diffchoice').value = savediff
-                     finddiff = true
-                  }
-         }
-      }
-      if (!finddiff)
-         document.getElementById('diffchoice').value = 'expert'
-      return 
-   }
-
    function sortstrength(){
    	min = parseInt(document.getElementById("strength0").innerHTML)
    	minnum = 0
@@ -1966,13 +1923,6 @@ function calc_bestarm(){
       document.getElementById('cardstrength'+String(mincard)).style.color = 'red'
    }
 
-   function changemapcolor(){
- //     document.getElementById('secondbase').innerHTML = document.getElementById('map').value
-      document.getElementById('secondbase2').innerHTML = document.getElementById('map').value
-      document.getElementById('base2').value = document.getElementById('map').value
-      document.getElementById('bonus2').value = document.getElementById('map').value
-   }
-
    function callback(){
    	alert('4')
    }
@@ -2020,12 +1970,12 @@ function calc_bestarm(){
 		<option value="muse">μ's</option>
 		<option value="aqours">Aqours</option>
 	</select><br>
-歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
+歌曲：<select id="songchoice" name="songchoice">
 		<option value=""> </option>
 	</select>
 	<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	<br>
-   难度：<select id="diffchoice" name="diffchoice" onchange="changesongcolor('songchoice')">
+   难度：<select id="diffchoice" name="diffchoice">
       <option value="easy">easy</option>
       <option value="normal">normal</option>
       <option value="hard">hard</option>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -39,7 +39,6 @@
    attcolor["smile"] = "red"
    attcolor["pure"] = "green"
    attcolor["cool"] = "blue"
-   attcolor[""] = "purple"
    var kizuna = new Array();
    kizuna["N"] = [25, 50]
    kizuna["R"] = [100, 200]
@@ -270,11 +269,6 @@
    	return false;
    }
 
-   function changesongselect(){
-      llsong.filterSongs();
-      changesongcolor("songchoice")
-   }
-
    function changecardselect(){
       var rarity = document.getElementById("rarity").value
       var chr = document.getElementById("chr").value
@@ -323,43 +317,29 @@
    	changeavatarselect()
    }
 
-   function changesongcolor(which){
-      var index = llsong.getSelectedSongIndex(which);
-      if (index != "") {
-         var diff = document.getElementById('diffchoice').value;
-         var songattr = llsong.getSongAttr(index);
+   function changemapcolor(attr) {
+      if (attr === undefined) attr = document.getElementById('map').value;
+      // do not update base, secondbase, bonus, because they are set by center
+      document.getElementById('map').style.color = llsong.attcolor[attr];
+      if (attr == llsong.getSongAttr()) document.getElementById('songchoice').style.color = llsong.attcolor[attr];
+      document.getElementById('secondbase2').innerHTML = attr;
+      if (document.getElementById("percentage2").value != 12) document.getElementById('base2').value = attr;
+      document.getElementById('bonus2').value = attr;
+   }
 
-         var c = attcolor[songattr];
-         document.getElementById(which).style.color = c;
-         document.getElementById("secondbase").innerHTML = songattr;
-         document.getElementById("secondbase2").innerHTML = songattr;
-         selectlist = ["map", "bonus", "bonus2"];
-         for (var i in selectlist){
-            document.getElementById(selectlist[i]).value = songattr;
-         }
-         if (document.getElementById("percentage").value != 12)
-            document.getElementById("base").value = songattr;
-         if (document.getElementById("percentage2").value != 12)
-            document.getElementById("base2").value = songattr;
-         infolist = ["combo",  "time"]
-         for (i in infolist){
-            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
-         }
-         if (document.getElementById("time").value == ""){
-            document.getElementById("time").value = 110
-         }
-         totalweight = 0
-         for (i = 0; i < 9; i++)
-            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
-         c = parseInt(llsong.songs[index][diff].combo)
-         sl = (totalweight-c)*100/0.25/c
-         //document.getElementById('slider').value = sl.toFixed(1)
-         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-         for (i = 0; i < 9; i++){
-            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
-         }
-      }
+   function applysongdata() {
+      var handleTime = function(t) { document.getElementById("time").value = (t ? t : 110); };
+      var handlePerfect = function(combo) { document.getElementById("perfect").value = parseInt(combo*19/20); };
+      var handleStar = function() { document.getElementById("starperfect").value = 0; };
+      var handleWeight = function(w) { for (var i = 0; i < 9; i++) { document.getElementById("weight"+i).value = parseFloat(w[i]); } };
+      var applyTarget = {
+         'attribute': ['map', changemapcolor],
+         'combo': ['combo', handlePerfect],
+         'time': [handleTime],
+         'star': [handleStar],
+         'positionweight': [handleWeight]
+      };
+      llsong.applyDataOfSongWithDiff(applyTarget);
    }
 
    function cardidtoindex(n){
@@ -462,8 +442,8 @@
       var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
+      llsong.onSongFilterChange();
       changecardselect()
-      changesongselect()
       document.getElementById("cardchoice").value = cardchoice
    }
 
@@ -561,7 +541,10 @@
          language = 0
 
       llsong.language = language;
+      llsong.onDiffSelectChange = applysongdata;
       llsong.showAllSongs();
+      llsong.initListeners();
+      llsong.initAttrSelectColor('map');
       getcardselect("", "", "", "", "", "");
       var inputs = document.getElementsByTagName("input");
       var selects = document.getElementsByTagName("select");
@@ -591,38 +574,13 @@
 
          document.getElementById("songsearch").value = ""
          // above codes may select songs/cards/filters according to cookies, so refresh it...
-         changesongselect();
+         llsong.onSongFilterChange();
          changecardselect();
       } catch (err) {
         console.log(err);
       }
 
       {{additional_script|safe}}
-   }
-
-   function changediffinfo(){
-      savediff = document.getElementById('diffchoice').value
-      index = document.getElementById('songchoice').value
-
-      diffsel = document.getElementById('diffchoice')
-      diffsel.options.length = 0;
-      diffname = ['easy', 'normal', 'hard', 'expert','master']
-      finddiff = false
-      for (i in diffname){
-         diff = diffname[i]
-         if (llsong.songs[index][diff] != null){
-
-                  newOption = new Option(diff, diff)
-                  diffsel.options.add(newOption)
-                  if (savediff == diff){
-                     document.getElementById('diffchoice').value = savediff
-                     finddiff = true
-                  }
-         }
-      }
-      if (!finddiff)
-         document.getElementById('diffchoice').value = 'expert'
-      return
    }
 
    function sortstrength(){
@@ -1260,13 +1218,6 @@
       document.getElementById('resultmic').innerHTML = micDisplayString + ' (' + micRawValue.toLocaleString() + (micDisplayValue % 1 === 0.0 ? '' : ', 该数值对应的援力暂时未知, 欢迎反馈') + ')'
    }
 
-   function changemapcolor(){
-      document.getElementById('secondbase').innerHTML = document.getElementById('map').value
-      document.getElementById('secondbase2').innerHTML = document.getElementById('map').value
-      document.getElementById('base2').value = document.getElementById('map').value
-      document.getElementById('bonus2').value = document.getElementById('map').value
-   }
-
    function callback(){
    	alert('4')
    }
@@ -1296,25 +1247,25 @@
 <form action="" id="unitform" name="unitform" method="POST" onsubmit="return check()" enctype=multipart/form-data>
 <!--<form action="/llloadunit"  onsubmit=""  target="if">-->
 <h3>歌曲信息</h3>
-搜索：<input type="text" id="songsearch" name="songsearch" value="" onchange="changesongselect()"></input><br>
+搜索：<input type="text" id="songsearch" name="songsearch" value=""></input><br>
 筛选：
-	<select id="songatt" name="songatt" onchange="changesongselect()">
+	<select id="songatt" name="songatt">
 		<option value="">属性</option>
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
 	</select>
-	<select id="songunit" name="songunit" onchange="changesongselect()">
+	<select id="songunit" name="songunit">
 		<option value="">组合</option>
 		<option value="muse">μ's</option>
 		<option value="aqours">Aqours</option>
 	</select><br>
-歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
+歌曲：<select id="songchoice" name="songchoice">
 		<option value=""> </option>
 	</select>
 	<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	<br>
-   难度：<select id="diffchoice" name="diffchoice" onchange="changesongcolor('songchoice')">
+   难度：<select id="diffchoice" name="diffchoice">
       <option value="easy">easy</option>
       <option value="normal">normal</option>
       <option value="hard">hard</option>
@@ -1730,7 +1681,7 @@
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>的<nospan id="secondbase" name="secondbase">
-   歌曲属性
+   属性
    <!--
       <option value="smile" style="color:red">smile</option>
       <option value="pure" style="color:green">pure</option>

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -279,11 +279,6 @@
    	return false;
    }
    
-   function changesongselect(){
-      llsong.filterSongs();
-      changesongcolor("songchoice")
-   }
-   
    function changecardselect(){
       rarity = document.getElementById("rarity").value
       chr = document.getElementById("chr").value
@@ -332,45 +327,31 @@
    	changeavatarselect()
    }
    
-   function changesongcolor(which){
-      var index = llsong.getSelectedSongIndex(which);
-      if (index != "") {
-         var diff = document.getElementById('diffchoice').value;
-         var songattr = llsong.getSongAttr(index);
-
-         var c = attcolor[songattr];
-         document.getElementById(which).style.color = c;
-//         document.getElementById("secondbase").innerHTML = songattr;
-         document.getElementById("secondbase2").innerHTML = songattr;
-         selectlist = ["map", "bonus2"];
-         for (var i in selectlist) {
-            document.getElementById(selectlist[i]).value = songattr;
-         }
-//   		if (document.getElementById("percentage").value != 12)
-//   			document.getElementById("base").value = songattr;
-         if (document.getElementById("percentage2").value != 12)
-            document.getElementById("base2").value = songattr;
-         infolist = ["combo",  "time"]
-         for (i in infolist){
-            document.getElementById(infolist[i]).value = llsong.songs[index][diff][infolist[i]]
-         }
-         if (document.getElementById("time").value == ""){
-            document.getElementById("time").value = 110
-         }
-         totalweight = 0
-         for (i = 0; i < 9; i++)
-            totalweight += parseFloat(llsong.songs[index][diff]['positionweight'][i])
-         c = parseInt(llsong.songs[index][diff].combo)
-         sl = (totalweight-c)*100/0.25/c
-         //document.getElementById('slider').value = sl.toFixed(1)
-         document.getElementById("perfect").value = parseInt(parseInt(document.getElementById("combo").value)*19/20)
-         document.getElementById("starperfect").value = 0//parseInt(parseInt(document.getElementById("star").value)*19/20)
-         for (i = 0; i < 9; i++){
-            document.getElementById("weight"+String(i)).value = parseFloat(llsong.songs[index][diff]["positionweight"][i])
-         }
-      }
+   function changemapcolor(attr) {
+      if (attr === undefined) attr = document.getElementById('map').value;
+      // do not update base, secondbase, bonus, because they are set by center
+      document.getElementById('map').style.color = llsong.attcolor[attr];
+      if (attr == llsong.getSongAttr()) document.getElementById('songchoice').style.color = llsong.attcolor[attr];
+      document.getElementById('secondbase2').innerHTML = attr;
+      if (document.getElementById("percentage2").value != 12) document.getElementById('base2').value = attr;
+      document.getElementById('bonus2').value = attr;
    }
-   
+
+   function applysongdata() {
+      var handleTime = function(t) { document.getElementById("time").value = (t ? t : 110); };
+      var handlePerfect = function(combo) { document.getElementById("perfect").value = parseInt(combo*19/20); };
+      var handleStar = function() { document.getElementById("starperfect").value = 0; };
+      var handleWeight = function(w) { for (var i = 0; i < 9; i++) { document.getElementById("weight"+i).value = parseFloat(w[i]); } };
+      var applyTarget = {
+         'attribute': ['map', changemapcolor],
+         'combo': ['combo', handlePerfect],
+         'time': [handleTime],
+         'star': [handleStar],
+         'positionweight': [handleWeight]
+      };
+      llsong.applyDataOfSongWithDiff(applyTarget);
+   }
+
    function cardidtoindex(n){
    	cardid = parseInt(n)
    	for (i in cards){
@@ -485,8 +466,8 @@
       var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
+      llsong.onSongFilterChange();
       changecardselect()
-      changesongselect()
       document.getElementById("cardchoice").value = cardchoice
    }
    
@@ -577,17 +558,20 @@
    }
    
    function init(){
-   	//document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
+      //document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
       skilllevel = 0
-   	mezame = getCookie("mezameunit")
-   	language = getCookie("languageunit")
-   	if (mezame == "")
-   		mezame = 0
-   	if (language == "")
-   		language = 0
-   	
+      mezame = getCookie("mezameunit")
+      language = getCookie("languageunit")
+      if (mezame == "")
+         mezame = 0
+      if (language == "")
+         language = 0
+
       llsong.language = language;
+      llsong.onDiffSelectChange = applysongdata;
       llsong.showAllSongs();
+      llsong.initListeners();
+      llsong.initAttrSelectColor('map');
    	getcardselect("", "", "", "", "", "");
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
@@ -614,40 +598,15 @@
          calslot(i)
    	}
       
-   	document.getElementById("songsearch").value = ""
+         document.getElementById("songsearch").value = ""
          // above codes may select songs/cards/filters according to cookies, so refresh it...
-         changesongselect();
+         llsong.onSongFilterChange();
          changecardselect();
       } catch (err) {}
 
       {{additional_script|safe}}
    }
    
-   function changediffinfo(){
-      savediff = document.getElementById('diffchoice').value
-      index = document.getElementById('songchoice').value
-
-      diffsel = document.getElementById('diffchoice')
-      diffsel.options.length = 0;
-      diffname = ['easy', 'normal', 'hard', 'expert','master']
-      finddiff = false
-      for (i in diffname){
-         diff = diffname[i]
-         if (llsong.songs[index][diff] != null){
-
-                  newOption = new Option(diff, diff)
-                  diffsel.options.add(newOption)
-                  if (savediff == diff){
-                     document.getElementById('diffchoice').value = savediff
-                     finddiff = true
-                  }
-         }
-      }
-      if (!finddiff)
-         document.getElementById('diffchoice').value = 'expert'
-      return 
-   }
-
    function sortstrength(){
    	min = parseInt(document.getElementById("strength0").innerHTML)
    	minnum = 0
@@ -1584,13 +1543,6 @@ function calc_bestarm(){
       document.getElementById('cardstrength'+String(mincard)).style.color = 'red'
    }
 
-   function changemapcolor(){
- //     document.getElementById('secondbase').innerHTML = document.getElementById('map').value
-      document.getElementById('secondbase2').innerHTML = document.getElementById('map').value
-      document.getElementById('base2').value = document.getElementById('map').value
-      document.getElementById('bonus2').value = document.getElementById('map').value
-   }
-
    function callback(){
    	alert('4')
    }
@@ -1623,25 +1575,25 @@ function calc_bestarm(){
 <form action="" id="unitform" name="unitform" method="POST" onsubmit="return check()" enctype=multipart/form-data>
 <!--<form action="/llloadunit"  onsubmit=""  target="if">-->
 <h3>歌曲信息</h3>
-搜索：<input type="text" id="songsearch" name="songsearch" value="" onchange="changesongselect()"></input><br>
+搜索：<input type="text" id="songsearch" name="songsearch" value=""></input><br>
 筛选：
-	<select id="songatt" name="songatt" onchange="changesongselect()">
+	<select id="songatt" name="songatt">
 		<option value="">属性</option>
 		<option value="smile">smile</option>
 		<option value="pure">pure</option>
 		<option value="cool">cool</option>
 	</select>
-	<select id="songunit" name="songunit" onchange="changesongselect()">
+	<select id="songunit" name="songunit">
 		<option value="">组合</option>
 		<option value="muse">μ's</option>
 		<option value="aqours">Aqours</option>
 	</select><br>
-歌曲：<select id="songchoice" name="songchoice" onchange="changediffinfo();changesongcolor('songchoice')">
+歌曲：<select id="songchoice" name="songchoice">
 		<option value=""> </option>
 	</select>
 	<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	<br>
-   难度：<select id="diffchoice" name="diffchoice" onchange="changesongcolor('songchoice')">
+   难度：<select id="diffchoice" name="diffchoice">
       <option value="easy">easy</option>
       <option value="normal">normal</option>
       <option value="hard">hard</option>

--- a/templates/llsongdata.html
+++ b/templates/llsongdata.html
@@ -19,7 +19,7 @@
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
-   var llsong = new LLSong(songsjson);
+   var llsong = new LLSong(songsjson, false);
    var language = 0
    
    function kizuna(combo){
@@ -53,171 +53,104 @@
       else
       	return (1.35*(cb-800)+970)/cb
    }
-   
-   function changesongselect(){
-      llsong.filterSongs();
-      changesonginfo("songchoice")
-   }
-   
-   function changediffinfo(){
+
+   function applysongdata() {
       var index = llsong.getSelectedSongIndex();
-      var diffsel = document.getElementById('diffchoice');
-      var savediff = diffsel.value;
-      var songdiff = document.getElementById('songdiff').value
-      //smnum =document.getElementById("smfilter").value
-      //mfnum =document.getElementById("mffilter").value
+      if (index == "") return;
 
-      diffsel.options.length = 0;
-      if (index == '') return;
-      var diffname = ['easy', 'normal', 'hard', 'expert', 'master'];
-      var finddiff = false;
+      var applyTarget = {
+         'attrcolor': ['songchoice', 'attribute', 'name', 'jpname']
+      };
+      var infolist = ['attribute', 'totaltime', 'bpm', 'name', 'jpname',
+        'combo', 'time', 'stardifficulty', 'randomdifficulty', 'star', 'cscore', 'bscore', 'ascore', 'sscore', 'lp', 'exp'];
+      for (var i in infolist) {
+         applyTarget[infolist[i]] = [[infolist[i], 'innerHTML']];
+      }
+      llsong.applyDataOfSongWithDiff(applyTarget);
+
+      var diff = document.getElementById('diffchoice').value;
       var curSong = llsong.songs[index];
-      for (var i in diffname){
-         var diff = diffname[i];
-         var curSongWithDiff = curSong[diff];
-         if (curSongWithDiff){
-            cnhave = '';
-            if (((curSongWithDiff['cnhave'] == cnhave) || (cnhave == ''))) {
-               var newOption = new Option(diff, diff);
-               diffsel.options.add(newOption);
-               if (savediff == diff){
-                  diffsel.value = savediff;
-                  finddiff = true;
-               }
-            }
-         }
-      }
-      if (!finddiff) {
-         if (songdiff != "") {
-            diffsel.value = songdiff;
-         } else {
-            diffsel.value = 'expert';
-         }
-      }
-      return 
-   }
+      var curSongWithDiff = curSong[diff];
 
-   function changesonginfo(which){
-      var index = llsong.getSelectedSongIndex(which);
-      if (index != "") {
-         var diff = document.getElementById('diffchoice').value;
-         var songAttr = llsong.getSongAttr(index);
-         var curSong = llsong.songs[index];
-         var curSongWithDiff = curSong[diff];
-         var c = llsong.attcolor[songAttr];
-         document.getElementById(which).style.color = c;
-         document.getElementById("attribute").innerHTML = songAttr;
-         //改颜色
-         colorList = ["attribute", "name","jpname"]
-         for (i in colorList){
-            document.getElementById(colorList[i]).style.color = c;
-         }
+      if (curSong['jpname'] == curSong['name']){
+         document.getElementById("name").style.display = "none"
+         document.getElementById("cnametag").style.display = "none"
+      }
+      else{
+         document.getElementById("name").style.display = ""
+         document.getElementById("cnametag").style.display = ""
+      }
 
-         songinfolist = ["totaltime","bpm","name","jpname"]
-         diffinfolist = ["combo", "time", "stardifficulty", "randomdifficulty","star",  "cscore", "bscore", "ascore", "sscore","lp","exp"]
-         songextend = ["秒", "", "", ""]
-         diffextend = ["", "秒", "", "", "",  "", "", "", "", "", "", "", "","","","","",""]
-         if (curSong['jpname'] == curSong['name']){
-            document.getElementById("name").style.display = "none"
-            document.getElementById("cnametag").style.display = "none"
+      var totalweight = 0;
+      var weights = curSongWithDiff.positionweight;
+      var c = parseInt(curSongWithDiff.combo);
+      for (var i = 0; i < 9; i++) {
+         totalweight += parseFloat(weights[i]);
+         document.getElementById('positionweight' + i).innerHTML = weights[i];
+      }
+      var sl = (totalweight-c)*100/0.25/c;
+      document.getElementById('noteweight').innerHTML = totalweight;
+      for (var i = 0; i < 9; i++) {
+         var p = parseFloat(weights[i]);
+         var percentage = p/(c*(1+0.0025*sl));
+         document.getElementById("positionmulti"+i).innerHTML = String((10*percentage).toFixed(3))+"%";
+      }
+      //隐藏没有的信息
+      hidelist = ["randomdifficulty"]
+      for (var i in hidelist){
+         if (curSongWithDiff[hidelist[i]] == ""){
+            document.getElementById(hidelist[i]).style.display = "none"
+            document.getElementById(hidelist[i]+"tag").style.display = "none"
          }
          else{
-            document.getElementById("name").style.display = ""
-            document.getElementById("cnametag").style.display = ""
+            document.getElementById(hidelist[i]).style.display = ""
+            document.getElementById(hidelist[i]+"tag").style.display = ""
          }
-         for (i in songinfolist){
-            document.getElementById(songinfolist[i]).innerHTML = curSong[songinfolist[i]]+songextend[i]
-         }
-         for (i in diffinfolist){
-            document.getElementById(diffinfolist[i]).innerHTML = curSong[diff][diffinfolist[i]]+diffextend[i]
-         }
+      }
+      //其他信息
+      document.getElementById("kizunaget").innerHTML = kizuna(c);
+      document.getElementById("combomulti").innerHTML = combomulti(c).toFixed(3);
+      document.getElementById("scoreperstrength").innerHTML = (1.1*1.1/80*combomulti(c)*totalweight).toFixed(3);
 
-         arraylist = ["positionweight"]
-         for (i in arraylist){
-            for (j = 0; j < 9; j++){
-               document.getElementById(arraylist[i]+String(j)).innerHTML=curSong[diff][arraylist[i]][j]
-            }
-         }
-         totalweight = 0
-         for (i = 0; i < 9; i++)
-            totalweight += parseFloat(curSongWithDiff['positionweight'][i])
-         c = parseInt(curSongWithDiff.combo)
-         sl = (totalweight-c)*100/0.25/c
-         document.getElementById('noteweight').innerHTML = String(totalweight)
-         for (i = 0; i < 9; i++){
-            p = parseFloat(curSongWithDiff.positionweight[i])
-            percentage = p/(c*(1+0.0025*sl))
-            document.getElementById("positionmulti"+String(i)).innerHTML=String((10*percentage).toFixed(3))+"%"
-         }
-         //隐藏没有的信息
-         hidelist = ["randomdifficulty"]
-         for (i in hidelist){
-            if (curSongWithDiff[hidelist[i]] == ""){
-               document.getElementById(hidelist[i]).style.display = "none"
-               document.getElementById(hidelist[i]+"tag").style.display = "none"
-            }
-            else{
-               document.getElementById(hidelist[i]).style.display = ""
-               document.getElementById(hidelist[i]+"tag").style.display = ""
-            }
-         }
-         //其他信息
-         document.getElementById("kizunaget").innerHTML = kizuna(parseInt(curSongWithDiff.combo))
-         document.getElementById("combomulti").innerHTML = combomulti(parseInt(curSongWithDiff.combo)).toFixed(3)
-         document.getElementById("scoreperstrength").innerHTML = (1.1*1.1/80*combomulti(c)*totalweight).toFixed(3)
+      //属性需求信息
+      /*
+      cbmulti = combomulti(parseInt(curSongWithDiff.combo))
+      rankList = ['c', 'b', 'a', 's']
+      for (i in rankList){
+         if (curSongWithDiff[rankList+"score"] == "")
+            continue
+         //document.getElementById(rankList[i]+"lowatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/cbmulti/c/(1+0.0025*sl)*80/1.1)
+         //document.getElementById(rankList[i]+"stableatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/c/(1+0.0025*sl)/0.99*80/1.1)
+      }
+      */
 
-         //属性需求信息
-         cbmulti = combomulti(parseInt(curSongWithDiff.combo))
-         rankList = ['c', 'b', 'a', 's']
-         for (i in rankList){
-            if (curSongWithDiff[rankList+"score"] == "")
-               continue
-            //document.getElementById(rankList[i]+"lowatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/cbmulti/c/(1+0.0025*sl)*80/1.1)
-            //document.getElementById(rankList[i]+"stableatt").innerHTML = parseInt(parseInt(curSongWithDiff[rankList[i]+"score"])/c/(1+0.0025*sl)/0.99*80/1.1)
-         }
-
-         //高亮低权重位置
-         we = new Array(8)
-         po = [0, 1, 2 ,3 ,5 ,6, 7, 8]
-         for (i = 0; i < 4; i++){
-            we[i] = parseFloat(curSongWithDiff.positionweight[i])
-         }
-         for (i = 5; i < 9; i++){
-            we[i-1] = parseFloat(curSongWithDiff.positionweight[i])
-         }
-         for (i = 0; i < 8; i ++){
-            for (j = 0; j < 7; j++){
-               if (we[j] > we[j+1]){
-                  tmp = we[j]
-                  we[j] = we[j+1]
-                  we[j+1] = tmp
-                  tmp = po[j]
-                  po[j] = po[j+1]
-                  po[j+1] = tmp
-               }
-            }
-         }
-         for (i = 0; i < 9; i++){
-            document.getElementById("positionweight"+String(i)).style.background = ""
-         }
-         document.getElementById("positionweight"+String(po[0])).style.background = "#f2dede"
-         document.getElementById("positionweight"+String(po[0])).style.color = "#a94442"
-         document.getElementById("positionweight"+String(po[1])).style.background = "#fcf8e3"
-         document.getElementById("positionweight"+String(po[1])).style.color = "#8a6d3b"
-         document.getElementById("positionweight"+String(po[2])).style.background = "#ffffcc"
-         document.getElementById("positionweight"+String(po[2])).style.color = "#a0a003"
+      //高亮低权重位置
+      var we = [];
+      for (var i = 0; i < 9; i++) {
+         if (i != 4) we.push([i, weights[i]]);
+      }
+      we.sort(function (a, b) { return a[1] - b[1]; });
+      for (var i = 0; i < 9; i++) {
+         document.getElementById("positionweight"+i).style.background = ""
+         document.getElementById("positionweight"+i).style.color = ""
+      }
+      var highlights = [["#f2dede", "#a94442"], ["#fcf8e3", "#8a6d3b"], ["#ffffcc", "#a0a003"]];
+      for (var i = 0; i < highlights.length; i++) {
+         document.getElementById("positionweight"+we[i][0]).style.background = highlights[i][0];
+         document.getElementById("positionweight"+we[i][0]).style.color = highlights[i][1];
       }
    }
    
    function changeLanguage(){
    	  language = 1-language
       llsong.language = language;
-	  changesongselect()
+      llsong.onSongFilterChange();
    }
    
    function init(){
-      //llsong.filterSongs();
-	  changesongselect()
+      llsong.onDiffSelectChange = applysongdata;
+      llsong.initListeners();
+      llsong.onSongFilterChange();
    }
    
    document.addEventListener("change", function () {
@@ -241,10 +174,10 @@
 
 {% block main %}
 <div class="form-group">
-<label class="control-label">搜索</label><input class="form-control" type="text" id="search" value="" onchange="changesongselect()"></input>
+<label class="control-label">搜索</label><input class="form-control" type="text" id="songsearch" value=""></input>
 </div>
 <div class="form-group">
-<label class="control-label">筛选</label><select class="form-control" id="songdiff" name="songdiff" onchange="changesongselect();changediffinfo()">
+<label class="control-label">筛选</label><select class="form-control" id="songdiff" name="songdiff">
 		<option value="">难度</option>
 		<option value="easy">包含easy难度</option>
 		<option value="normal">包含normal难度</option>
@@ -252,13 +185,13 @@
 		<option value="expert">包含expert难度</option>
 		<option value="master">包含master难度</option>
 	</select>
-	<select class="form-control" id="songatt" name="songatt" onchange="changesongselect()">
+	<select class="form-control" id="songatt" name="songatt">
 		<option value="">属性</option>
 		<option value="smile">Smile</option>
 		<option value="pure">Pure</option>
 		<option value="cool">Cool</option>
 	</select>
-	<select class="form-control" id="songunit" name="songunit" onchange="changesongselect()">
+	<select class="form-control" id="songunit" name="songunit">
 		<option value="">组合</option>
 		<option value="muse">μ's</option>
 		<option value="aqours">Aqours</option>
@@ -310,12 +243,13 @@
       <option value="7">第七次MF</option>
    </select>-->
 <div class="form-group">
-<label class="control-label">歌曲</label><select class="form-control" id="songchoice" name="songchoice" onchange="changediffinfo();changesonginfo('songchoice');">
+<label class="control-label">歌曲</label><select class="form-control" id="songchoice" name="songchoice">
 		<option value=""> </option>
 </select>
+<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 </div>
 <div class="form-group">
-<label class="control-label">难度</label><select class="form-control" id="diffchoice" name="diffchoice" onchange="changesonginfo('songchoice')">
+<label class="control-label">难度</label><select class="form-control" id="diffchoice" name="diffchoice">
       <option value="easy">easy</option>
       <option value="normal">normal</option>
       <option value="hard">hard</option>
@@ -344,9 +278,9 @@
 	<dt>按键权重</dt>
 	<dd id='noteweight'> </dd>
 	<dt>时间</dt>
-	<dd><span id='time'></span><sup><a href="#intro-1">(1)</a></sup></dd>
+	<dd><span id='time'></span>秒<sup><a href="#intro-1">(1)</a></sup></dd>
 	<dt>歌曲长度</dt>
-	<dd><span id='totaltime'></span><sup><a href="#intro-2">(2)</a></sup></dd>
+	<dd><span id='totaltime'></span>秒<sup><a href="#intro-2">(2)</a></sup></dd>
 	<dt>BPM</dt>
 	<dd id='bpm'> </dd>
 	<dt>星星数</dt>


### PR DESCRIPTION
New features:
* Add color to map attribute choice
![pr2-](https://user-images.githubusercontent.com/17180510/36734100-82f75b76-1c0d-11e8-838b-ba27e79eaa0c.png)
* When selected default song, changing map attribute will also change the default song color
![pr2-](https://user-images.githubusercontent.com/17180510/36734115-8939d248-1c0d-11e8-9d29-e8a455e5cc2d.png)


Fixes:
* Fixed regression in `llnewautounit`

Enhancement for developer:
* Unified and moved song difficult choice logic to `llsong.js` and reuse in `llcoverage`, `llnewautounit`, `llnewunit`, `llnewunitsis`, `llsongdata`