### PR TITLE
Move card filter/select logic to single js and fix several issues

### DIFF
--- a/static/llcard.js
+++ b/static/llcard.js
@@ -1,0 +1,199 @@
+/*
+ * Common card filter/select script
+ *
+ * By ben1222
+ */
+
+function LLCard(cardjson) {
+   var cards = cardjson;
+   if (typeof(cards) == "string") {
+      cards = eval("("+cards+")");
+   }
+
+   this.cards = cards;
+   this.attcolor = {
+      'smile': 'red',
+      'pure': 'green',
+      'cool': 'blue'
+   };
+   this.nametojp = {
+      "高坂穗乃果": "高坂穂乃果",
+      "绚濑绘里": "絢瀬絵里",
+      "南小鸟": "南ことり",
+      "园田海未": "園田海未",
+      "星空凛": "星空凛",
+      "西木野真姬": "西木野真姫",
+      "东条希": "東條希",
+      "小泉花阳": "小泉花陽",
+      "矢泽妮可": "矢澤にこ",
+      "高海千歌": "高海千歌",
+      "樱内梨子": "桜内梨子",
+      "松浦果南": "松浦果南",
+      "黑泽黛雅": "黒澤ダイヤ",
+      "渡边曜": "渡辺曜",
+      "津岛善子": "津島善子",
+      "国木田花丸": "国木田花丸",
+      "小原鞠莉": "小原鞠莉",
+      "黑泽露比": "黒澤ルビィ"
+   };
+   this.unitgradechr = [
+      [],
+      ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
+      ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
+      ["絢瀬絵里","東條希","矢澤にこ","松浦果南","黒澤ダイヤ","小原鞠莉"],
+      ["高坂穂乃果","絢瀬絵里","南ことり","園田海未","星空凛","西木野真姫","東條希","小泉花陽","矢澤にこ"],
+      ["高海千歌","桜内梨子","松浦果南","黒澤ダイヤ","渡辺曜","津島善子","国木田花丸","小原鞠莉","黒澤ルビィ"],
+      ["高坂穂乃果","南ことり","小泉花陽"],
+      ["園田海未","星空凛","東條希"],
+      ["絢瀬絵里","西木野真姫","矢澤にこ"],
+      ["高海千歌","渡辺曜","黒澤ルビィ"],
+      ["松浦果南","黒澤ダイヤ","国木田花丸"],
+      ["桜内梨子","津島善子","小原鞠莉"]
+   ];
+   this.units = ['','1年生','2年生','3年生',"μ's",'Aqours','Printemps','lilywhite','BiBi','CYaRon!','AZALEA','Guilty Kiss'];
+   this.language = 0;
+   this.cardSelId = 'cardchoice';
+   this.cardRarityId = 'rarity';
+   this.cardChrId = 'chr';
+   this.cardAttId = 'att';
+   this.cardTypeId = 'cardtype';
+   this.cardSpecialId = 'special';
+   this.cardSkillTypeId = 'skilltype';
+   this.cardTriggerTypeId = 'triggertype';
+   this.cardSetNameId = 'setname';
+   this.cardShowNCardId = 'showncard';
+   this.cardUnitGradeId = 'unitgrade';
+   this.cardStrengthLowBoundId = 'lowbound';
+   this.calcCardMaxStrength = undefined;
+};
+
+// listeners
+LLCard.prototype.initListeners = function() {
+   var me = this;
+   var funcOnCardFilterChange = function() { me.onCardFilterChange(); };
+   var funcOnCardSelectChange = function() { me.onCardSelectChange(); };
+   this._listen(this.cardRarityId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardChrId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardAttId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardTypeId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardSpecialId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardSkillTypeId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardTriggerTypeId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardSetNameId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardShowNCardId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardUnitGradeId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardStrengthLowBoundId, 'change', funcOnCardFilterChange);
+   this._listen(this.cardSelId, 'change', funcOnCardSelectChange);
+};
+LLCard.prototype._listen = function(id, e, func) {
+   if (!(id && e && func)) return;
+   var element = document.getElementById(id);
+   if (!element) return;
+   element.addEventListener(e, func);
+};
+
+// gets
+LLCard.prototype.getElementValue = function (id, defaultValue) {
+   if (!id) return defaultValue;
+   var ret = undefined;
+   var element = document.getElementById(id);
+   if (element) ret = element.value;
+   if (ret === undefined) return defaultValue;
+   return ret;
+};
+LLCard.prototype.getElementChecked = function (id, defaultValue) {
+   if (!id) return defaultValue;
+   var ret = undefined;
+   var element = document.getElementById(id);
+   if (element) ret = element.checked;
+   if (ret === undefined) return defaultValue;
+   return ret;
+};
+LLCard.prototype.getElementOrThrow = function (id) {
+   if (!id) throw "Not given id";
+   var ret = document.getElementById(id);
+   if (!ret) throw ("Not found " + id);
+   return ret;
+};
+
+// event handlers
+LLCard.prototype.defaultOnCardFilterChange = function () {
+   this.filterCards();
+   this.onCardSelectChange();
+};
+LLCard.prototype.onCardFilterChange = LLCard.prototype.defaultOnCardFilterChange;
+LLCard.prototype.onCardSelectChange = function () {};
+
+// filters
+LLCard.prototype.filterCards = function (cardsel, rarity, chr, att, cardtype, special, skilltype, triggertype, setname, showncard, unitgrade, strlowbound) {
+   if (cardsel === undefined) cardsel = this.getElementOrThrow(this.cardSelId);
+   if (rarity === undefined) rarity = this.getElementValue(this.cardRarityId, "");
+   if (chr === undefined) chr = this.getElementValue(this.cardChrId, "");
+   if (att === undefined) att = this.getElementValue(this.cardAttId, "");
+   if (cardtype === undefined) cardtype = this.getElementValue(this.cardTypeId, "");
+   if (special === undefined) special = this.getElementValue(this.cardSpecialId, "");
+   if (skilltype === undefined) skilltype = this.getElementValue(this.cardSkillTypeId, "");
+   if (triggertype === undefined) triggertype = this.getElementValue(this.cardTriggerTypeId, "");
+   if (setname === undefined) setname = this.getElementValue(this.cardSetNameId, "");
+   if (showncard === undefined) showncard = this.getElementChecked(this.cardShowNCardId, false);
+   if (unitgrade === undefined) unitgrade = this.getElementValue(this.cardUnitGradeId, "");
+   if (strlowbound === undefined) strlowbound = this.getElementValue(this.cardStrengthLowBoundId, "");
+
+   var lastSelected = cardsel.value;
+   var keepLastSelected = false;
+   cardsel.options.length = 1;
+   var cardKeys = Object.keys(this.cards).sort(function(a,b){return parseInt(a) - parseInt(b);});
+   for (var i = 0; i < cardKeys.length; i++) {
+      var index = cardKeys[i];
+      if (index == "0") continue;
+      var curCard = this.cards[index];
+      if (curCard.support == 1) continue;
+
+      if (rarity && rarity != curCard.rarity) continue;
+      if (chr && curCard.jpname.indexOf(this.nametojp[chr]) == -1) continue;
+      if (att && att != curCard.attribute) continue;
+      if (special != "" && parseInt(special) != parseInt(curCard.special)) continue;
+      if (cardtype && curCard.type.indexOf(cardtype) == -1) continue;
+      if (skilltype != "" && skilltype != curCard.skilleffect) continue;
+      if (triggertype != "" && triggertype != curCard.triggertype) continue;
+      if (setname && setname != curCard.jpseries) continue;
+      if ((!showncard) && curCard.rarity == 'N') continue;
+      if (!this.isInUnitGroup(unitgrade, curCard.jpname)) continue;
+      if (strlowbound && this.calcCardMaxStrength && strlowbound > this.calcCardMaxStrength(curCard)) continue;
+
+      var fullname = String(curCard.id);
+      while (fullname.length < 3) fullname = '0' + fullname;
+      fullname += ' ' + curCard.rarity + ' ';
+      if (this.language == 0) {
+         fullname += (curCard.eponym ? "【"+curCard.eponym+"】" : '') + ' ' + curCard.name + ' ' + (curCard.series ? "("+curCard.series+")" : '');
+      } else {
+         fullname += (curCard.jpeponym ? "【"+curCard.jpeponym+"】" : '') + ' ' + curCard.jpname + ' ' + (curCard.jpseries ? "("+curCard.jpseries+")" : '');
+      }
+      var newOption = new Option(fullname, index);
+      newOption.style.color = this.attcolor[curCard.attribute];
+      cardsel.options.add(newOption);
+
+      if (index == lastSelected) keepLastSelected = true;
+   }
+   if (keepLastSelected) {
+      cardsel.value = lastSelected;
+   }
+};
+LLCard.prototype.showAllCards = function (cardsel) {
+   this.filterCards(cardsel, "", "", "", "", "", "", "", "", "", "", "");
+};
+
+// util
+LLCard.prototype.isInUnitGroup = function (unitgrade, character) {
+   if (!unitgrade) return true;
+   var chrs = this.unitgradechr[parseInt(unitgrade)];
+   if (!chrs) {
+      console.error("Not found unit " + unitgrade + ", character " + character);
+      return true;
+   }
+   for (var i = 0; i < chrs.length; i++) {
+      if (chrs[i] == character) return true;
+   }
+   return false;
+};
+

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -7,6 +7,7 @@
 {% block additional_header %}
    <script type="text/javascript" src="/static/twintailosu.js?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
    <script type="text/javascript" src="/static/js/highcharts/highstock.js"></script>
    <script type="text/javascript" src="/static/js/highcharts/exporting.js"></script>
    <script src="https://app.lovelivewiki.com/Maps/songsjson.js"></script>
@@ -27,31 +28,14 @@
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
    var llsong = new LLSong(songs, false); // songs defined in songsjson.js
+   var llcard = new LLCard(cards);
+
    var attcolor = new Array();
    var mezame = 0
    var language = 0
    attcolor["smile"] = "red"
    attcolor["pure"] = "green"
    attcolor["cool"] = "blue"
-   nametojp = new Array()
-   nametojp["高坂穗乃果"] = "高坂穂乃果"
-   nametojp["绚濑绘里"] = "絢瀬絵里"
-   nametojp["南小鸟"] = "南ことり"
-   nametojp["园田海未"] = "園田海未"
-   nametojp["星空凛"] = "星空凛"
-   nametojp["西木野真姬"] = "西木野真姫"
-   nametojp["东条希"] = "東條希"
-   nametojp["小泉花阳"] = "小泉花陽"
-   nametojp["矢泽妮可"] = "矢澤にこ"
-   nametojp["高海千歌"] = "高海千歌"
-   nametojp["樱内梨子"] = "桜内梨子"
-   nametojp["松浦果南"] = "松浦果南"
-   nametojp["黑泽黛雅"] = "黒澤ダイヤ"
-   nametojp["渡边曜"] = "渡辺曜"
-   nametojp["津岛善子"] = "津島善子"
-   nametojp["国木田花丸"] = "国木田花丸"
-   nametojp["小原鞠莉"] = "小原鞠莉"
-   nametojp["黑泽露比"] = "黒澤ルビィ"
    unitgradechr = [[],
                   ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
                   ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
@@ -128,16 +112,6 @@
 	    document.getElementById('offset').value = 0;
    }
    
-   function isinunitgroup(unitgrade, character){
-      if (unitgrade == 0)
-         return true
-      for (i in unitgradechr[unitgrade]){
-         if (unitgradechr[unitgrade][i] == character)
-            return true
-      }
-      return false
-   }
-
    function changeskilllevel(){
       document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
       index = document.getElementById('cardchoice').value
@@ -200,67 +174,8 @@
     }
    }
    
-   function getcardselect(rarity, chr, att, cardtype, special){
-      sel = document.getElementById("cardchoice");
-      skilltype = "5"
-      triggertype = document.getElementById("triggertype").value
-      setname = document.getElementById("setname").value
-      unitgrade = document.getElementById("unitgrade").value
-      sel.options.length = 1;
-      var index = 1;
-      //alert(chr)
-      for (card in cards){
-         if (!cards[index]) continue
-         if (((rarity == "") || (rarity == cards[index].rarity)) && ((chr == "") || (cards[index].jpname.indexOf(nametojp[chr]) != -1)) && ((att == "") || (att == cards[index].attribute)) && ((special == "") || ((cards[index].special == 0) && (special == 0)) || ((cards[index].special == 1) && (special == 1))) && ((cardtype == "") || (cards[index].type.indexOf(cardtype) != -1)) && ((skilltype == "") || (skilltype == cards[index].skilleffect)) && ((triggertype == "") || (triggertype == cards[index].triggertype)) && ((setname == "") || (setname == cards[index].jpseries))){
-            //if ((!(document.getElementById('showncard').checked) && (cards[index].rarity == 'N')) || (cards[index].support == 1)){
-             //  index += 1
-            //   continue
-            //}
-            if (!isinunitgroup(unitgrade, cards[index].jpname)){
-               index += 1
-               continue
-            }
-            var newOption
-            if (cards[index].eponym) {eponym = "【"+cards[index].eponym+"】"} else eponym = ""
-            if (cards[index].series && (cards[index].series != '')) {series = "("+cards[index].series+")"} else series = ""
-            if (cards[index].jpeponym) {jpeponym = "【"+cards[index].jpeponym+"】"} else jpeponym = ""
-            if (cards[index].jpseries && (cards[index].jpseries != '')) {jpseries = "("+cards[index].jpseries+")"} else jpseries = ""
-            if (language == 0)
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+eponym+cards[index].name+" "+series, index)
-            else
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+jpeponym+cards[index].jpname+" "+jpseries, index)
-            newOption.style.color = attcolor[cards[index].attribute]
-            sel.options.add(newOption)
-         }
-         index += 1
-      }
-      //changecolor("cardchoice")
-   }
-   
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
-   
-   function changecardselect(){
-      rarity = document.getElementById("rarity").value
-      chr = document.getElementById("chr").value
-      att = document.getElementById("att").value
-      cardtype = document.getElementById("cardtype").value
-      special = 0
-      var cardchoice = document.getElementById("cardchoice").value
-      getcardselect(rarity, chr, att, cardtype, special)
-      if (havevalue("cardchoice", cardchoice)){
-         document.getElementById("cardchoice").value = cardchoice
-      }
-      changecolor("cardchoice")
-   }
-   
-   function changecolor(which){
+   function changecolor(){
+      var which = "cardchoice";
    	index = document.getElementById(which).value
    	if (index != "") {
    		c = attcolor[cards[index].attribute]
@@ -293,14 +208,6 @@
    	changeavatarselect()
    }
     
-   function tothree(string){
-   	str = String(string)
-   	while (str.length < 3){
-   		str = '0'+str
-   	}
-   	return str
-   }
- 
    function changeavatarselect(){
    	document.getElementById('imageselect').src = '/static/null.png'
    	cardid = 0
@@ -315,12 +222,11 @@
    }
    
    function changeLanguage(){
-      var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
       llsong.onSongFilterChange();
-      changecardselect()
-      document.getElementById("cardchoice").value = cardchoice
+      llcard.language = language;
+      llcard.onCardFilterChange();
    }
    
    function changeskilltext(n){
@@ -363,8 +269,7 @@
    
    function toMezame(){
    	mezame = 1-mezame
-   	changecolor("cardchoice")
-   	changeavatarselect()
+   	changecolor()
    }
 
    function applysongdata() {
@@ -474,8 +379,7 @@
       skilllevel = 0
    	mezame = getCookie("mezameperfect")
    	language = getCookie("languageperfect")
-   	if (mezame == "")
-   		mezame = 0
+      if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
    	if (language == "")
    		language = 0
    	
@@ -483,7 +387,12 @@
       llsong.onDiffSelectChange = applysongdata;
       llsong.showAllSongs();
       llsong.initListeners();
-   	getcardselect("", "", "", "", "");
+
+      llcard.language = language;
+      llcard.onCardSelectChange = changecolor;
+      llcard.showAllCards();
+      llcard.initListeners();
+
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
 	var nospan = document.getElementsByTagName("nospan");
@@ -500,10 +409,7 @@
    		if (getCookie("nospan"+String(i)+"perfect") != "")
    			nospan[i].innerHTML = getCookie("nospan"+String(i)+"perfect");
    	}
-   	if (mezame == 1)
-   		document.getElementById("mezame").checked = mezame
-   	//selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
-   	//selects["songchoice"].value = getCookie(selects["songchoice"].name);
+      document.getElementById("mezame").checked = mezame
    	changeskilltext("")
       changeskilllevel()
    	changeavatarselect()
@@ -511,13 +417,12 @@
 	    if (document.getElementById("member"+String(i)).value != 0){
    		    //changeskilltext(i)
    		    changeavatar(i)
-            //calslot(i)
 		}
    	}
       document.getElementById("songsearch").value = ""
       // above codes may select songs/cards/filters according to cookies, so refresh it...
       llsong.onSongFilterChange();
-      changecardselect();
+      llcard.onCardFilterChange();
    }
    
    </script>
@@ -600,13 +505,13 @@
 <br>
 
 <h3>判卡库</h3>
-筛选：<select id="rarity" name="rarity" onchange="changecardselect()">
+筛选：<select id="rarity" name="rarity">
       <option value="">稀有度</option>
       <option value="SR">SR</option>
       <option value="SSR">SSR</option>
       <option value="UR">UR</option>
    </select>
-   <select id="chr" name="chr" onchange="changecardselect()">
+   <select id="chr" name="chr">
       <option value="">角色</option>
       <option value="高坂穗乃果">高坂穗乃果</option>
       <option value="绚濑绘里">绚濑绘里</option>
@@ -627,7 +532,7 @@
       <option value="小原鞠莉">小原鞠莉</option>
       <option value="黑泽露比">黑泽露比</option>
    </select>
-   <select id="unitgrade" name="unitgrade" onchange="changecardselect()">
+   <select id="unitgrade" name="unitgrade">
       <option value="">年级小队</option>
       <option value="4">μ's</option>
       <option value="5">Aqours</option>
@@ -641,24 +546,27 @@
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>
-   <select id="att" name="att" onchange="changecardselect()">
+   <select id="att" name="att">
       <option value="">属性</option>
       <option value="smile" style="color:red">smile</option>
       <option value="pure" style="color:green">pure</option>
       <option value="cool" style="color:blue">cool</option>
    </select>
-   <select id="triggertype" name="triggertype" onchange="changecardselect()">
+   <select id="triggertype" name="triggertype">
       <option value="">触发类型</option>
       <option value="1">时间</option>
       <option value="3">图标</option>
       <option value="4">combo</option>
    </select>
-   <select id="cardtype" name="cardtype" onchange="changecardselect()">
+   <select id="skilltype" name="skilltype">
+      <option value="5">大判定</option>
+   </select>
+   <select id="cardtype" name="cardtype">
       <option value="">卡片类型</option>
       <option value="活动卡">活动卡</option>
       <option value="登录奖励">登录奖励</option>
    </select>
-   <select id="setname" name="setname" onchange="changecardselect()">
+   <select id="setname" name="setname">
       <option value="">套卡名</option>
       <option value="初期">初期</option>
       <option value="職業編">职业篇</option>
@@ -696,7 +604,7 @@
       <option value="妖精の国編">妖精之国篇</option>
    </select>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel();changecolor('cardchoice')">
+卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
 		<option value=""> </option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -7,6 +7,7 @@
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -22,6 +23,7 @@
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
    var llsong = new LLSong(songsjson);
+   var llcard = new LLCard(cardsjson);
 
    var attcolor = new Array();
    var mezame = 0
@@ -36,25 +38,6 @@
    kizuna["SR"] = [250, 500]
    kizuna["SSR"] = [375, 750]
    kizuna["UR"] = [500, 1000]
-   nametojp = new Array()
-   nametojp["高坂穗乃果"] = "高坂穂乃果"
-   nametojp["绚濑绘里"] = "絢瀬絵里"
-   nametojp["南小鸟"] = "南ことり"
-   nametojp["园田海未"] = "園田海未"
-   nametojp["星空凛"] = "星空凛"
-   nametojp["西木野真姬"] = "西木野真姫"
-   nametojp["东条希"] = "東條希"
-   nametojp["小泉花阳"] = "小泉花陽"
-   nametojp["矢泽妮可"] = "矢澤にこ"
-   nametojp["高海千歌"] = "高海千歌"
-   nametojp["樱内梨子"] = "桜内梨子"
-   nametojp["松浦果南"] = "松浦果南"
-   nametojp["黑泽黛雅"] = "黒澤ダイヤ"
-   nametojp["渡边曜"] = "渡辺曜"
-   nametojp["津岛善子"] = "津島善子"
-   nametojp["国木田花丸"] = "国木田花丸"
-   nametojp["小原鞠莉"] = "小原鞠莉"
-   nametojp["黑泽露比"] = "黒澤ルビィ"
    unitgradechr = [[],
                   ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
                   ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
@@ -122,16 +105,6 @@
       changeskilllevel()
    }
 
-   function isinunitgroup(unitgrade, character){
-      if (unitgrade == 0)
-         return true
-      for (i in unitgradechr[unitgrade]){
-         if (unitgradechr[unitgrade][i] == character)
-            return true
-      }
-      return false
-   }
-
    function changeskilllevel(){
       document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
       index = document.getElementById('cardchoice').value
@@ -149,7 +122,6 @@
          naipan = 480
       else
          naipan = 270
-      //changecolor('cardchoice')
    }
 
    pos = -1
@@ -272,67 +244,8 @@
       }
    }
 
-   function getcardselect(rarity, chr, att, cardtype,special){
-      sel = document.getElementById("cardchoice");
-      skilltype = document.getElementById("skilltype").value
-      triggertype = document.getElementById("triggertype").value
-      setname = document.getElementById("setname").value
-      unitgrade = document.getElementById("unitgrade").value
-      sel.options.length = 1;
-      var index = 1;
-      //alert(chr)
-      for (card in cards){
-         if (!cards[index]) continue
-         if (((rarity == "") || (rarity == cards[index].rarity)) && ((chr == "") || (cards[index].jpname.indexOf(nametojp[chr]) != -1)) && ((att == "") || (att == cards[index].attribute)) && ((special == "") || ((cards[index].special == 0) && (special == 0)) || ((cards[index].special == 1) && (special == 1))) && ((cardtype == "") || (cards[index].type.indexOf(cardtype) != -1)) && ((skilltype == "") || (skilltype == cards[index].skilleffect)) && ((triggertype == "") || (triggertype == cards[index].triggertype)) && ((setname == "") || (setname == cards[index].jpseries))){
-            if ((!(document.getElementById('showncard').checked) && (cards[index].rarity == 'N')) || (cards[index].support == 1)){
-               index += 1
-               continue
-            }
-            if (!isinunitgroup(unitgrade, cards[index].jpname)){
-               index += 1
-               continue
-            }
-            var newOption
-            if (cards[index].eponym) {eponym = "【"+cards[index].eponym+"】"} else eponym = ""
-            if (cards[index].series && (cards[index].series != '')) {series = "("+cards[index].series+")"} else series = ""
-            if (cards[index].jpeponym) {jpeponym = "【"+cards[index].jpeponym+"】"} else jpeponym = ""
-            if (cards[index].jpseries && (cards[index].jpseries != '')) {jpseries = "("+cards[index].jpseries+")"} else jpseries = ""
-            if (language == 0)
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+eponym+cards[index].name+" "+series, index)
-            else
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+jpeponym+cards[index].jpname+" "+jpseries, index)
-            newOption.style.color = attcolor[cards[index].attribute]
-            sel.options.add(newOption)
-         }
-         index += 1
-      }
-      //changecolor("cardchoice")
-   }
-   
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
-   
-   function changecardselect(){
-      rarity = document.getElementById("rarity").value
-      chr = document.getElementById("chr").value
-      att = document.getElementById("att").value
-      cardtype = document.getElementById("cardtype").value
-      special = document.getElementById("special").value
-      var cardchoice = document.getElementById("cardchoice").value
-      getcardselect(rarity, chr, att, cardtype, special)
-      if (havevalue("cardchoice", cardchoice)){
-         document.getElementById("cardchoice").value = cardchoice
-      }
-      changecolor("cardchoice")
-   }
-   
-   function changecolor(which){
+   function changecolor(){
+      var which = "cardchoice";
 
    	index = document.getElementById(which).value
    	if (index != "") {
@@ -463,22 +376,6 @@
       }
    }
    
-   function tothree(string){
-   	str = String(string)
-   	while (str.length < 3){
-   		str = '0'+str
-   	}
-   	return str
-   }
-   
-   function carddata(cardid){
-      for (index = 0; index < cards.length; index++){
-         if (cards[index]['id'] == cardid)
-            return cards[index]
-      }
-      return ''
-   }
-
    function changeavatar(n){
    	cardid = threetonumber(document.getElementById('cardid'+String(n)).value)
    	if ((cardid == 0) || (cardid == "") || (cardid == "0"))
@@ -504,12 +401,11 @@
    }
    
    function changeLanguage(){
-      var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
       llsong.onSongFilterChange();
-      changecardselect()
-      document.getElementById("cardchoice").value = cardchoice
+      llcard.language = language;
+      llcard.onCardFilterChange();
    }
    
    function changeskilltext(n){
@@ -552,11 +448,8 @@
    
    function toMezame(){
    	mezame = 1-mezame
-   	changecolor("cardchoice")
-   	changeavatarselect()
+   	changecolor()
    }
-   
-   
 
 
    function clearall(){
@@ -654,8 +547,7 @@
       skilllevel = 0
    	mezame = getCookie("mezameunit")
    	language = getCookie("languageunit")
-   	if (mezame == "")
-   		mezame = 0
+      if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
    	if (language == "")
    		language = 0
    	
@@ -664,7 +556,12 @@
       llsong.showAllSongs();
       llsong.initListeners();
       llsong.initAttrSelectColor('map');
-   	getcardselect("", "", "", "", "", "");
+
+      llcard.language = language;
+      llcard.onCardSelectChange = changecolor;
+      llcard.showAllCards();
+      llcard.initListeners();
+
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
    	for (var i=0; i<inputs.length; i++){
@@ -676,10 +573,7 @@
    		if (getCookie(selects[i].name+"unit") != "")
    			selects[i].value = getCookie(selects[i].name+"unit");
    	}
-   	if (mezame == 1)
-   		document.getElementById("mezame").checked = mezame
-   	//selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
-   	//selects["songchoice"].value = getCookie(selects["songchoice"].name);
+      document.getElementById("mezame").checked = mezame
    	changeskilltext("")
       changeskilllevel()
    	changeavatarselect()
@@ -691,7 +585,7 @@
       document.getElementById("songsearch").value = ""
       // above codes may select songs/cards/filters according to cookies, so refresh it...
       llsong.onSongFilterChange();
-      changecardselect();
+      llcard.onCardFilterChange();
 	document.getElementById("submembersoperation").style.display="none"
    }
    
@@ -1564,7 +1458,7 @@ function calc_bestarm(){
       }
       //副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
 		 ////////////////////
 		if(Precal&&(mapcenter['bonus']==mainatt)) Match_c[i]+=(mapcenter['secondpercentage']/100);
 		//////////////////////
@@ -1594,7 +1488,7 @@ function calc_bestarm(){
       }
       //好友副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
 		 ////////////////////
 		if(Precal &&(mapcenter['bonus2']==mainatt))
 		 Match_c[i]+=(mapcenter['secondpercentage2']/100);
@@ -1993,7 +1887,7 @@ function calc_bestarm(){
 	星星perfect数:<input type="text" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
 <h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity" onchange="changecardselect()">
+筛选：<select id="rarity" name="rarity">
       <option value="">稀有度</option>
       <option value="N">N</option>
       <option value="R">R</option>
@@ -2001,7 +1895,7 @@ function calc_bestarm(){
       <option value="SSR">SSR</option>
       <option value="UR">UR</option>
    </select>
-   <select id="chr" name="chr" onchange="changecardselect()">
+   <select id="chr" name="chr">
       <option value="">角色</option>
       <option value="高坂穗乃果">高坂穗乃果</option>
       <option value="绚濑绘里">绚濑绘里</option>
@@ -2022,7 +1916,7 @@ function calc_bestarm(){
       <option value="小原鞠莉">小原鞠莉</option>
       <option value="黑泽露比">黑泽露比</option>
    </select>
-   <select id="unitgrade" name="unitgrade" onchange="changecardselect()">
+   <select id="unitgrade" name="unitgrade">
       <option value="">年级小队</option>
       <option value="4">μ's</option>
       <option value="5">Aqours</option>
@@ -2036,13 +1930,13 @@ function calc_bestarm(){
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>
-   <select id="att" name="att" onchange="changecardselect()">
+   <select id="att" name="att">
       <option value="">属性</option>
       <option value="smile" style="color:red">smile</option>
       <option value="pure" style="color:green">pure</option>
       <option value="cool" style="color:blue">cool</option>
    </select>
-   <select id="triggertype" name="triggertype" onchange="changecardselect()">
+   <select id="triggertype" name="triggertype">
       <option value="">触发类型</option>
       <option value="1">时间</option>
       <option value="3">图标</option>
@@ -2051,24 +1945,24 @@ function calc_bestarm(){
       <option value="6">perfect</option>
       <option value="12">星星perfect</option>
    </select>
-   <select id="skilltype" name="skilltype" onchange="changecardselect()">
+   <select id="skilltype" name="skilltype">
       <option value="">技能类型</option>
       <option value="4">小判定</option>
       <option value="5">大判定</option>
       <option value="9">回血</option>
       <option value="11">加分</option>
    </select>
-   <select id="cardtype" name="cardtype" onchange="changecardselect()">
+   <select id="cardtype" name="cardtype">
       <option value="">卡片类型</option>
       <option value="活动卡">活动卡</option>
       <option value="登录奖励">登录奖励</option>
    </select>
-   <select id="special" name="special" onchange="changecardselect()">
+   <select id="special" name="special">
       <option value="">是否特典卡</option>
       <option value=0>不是特典</option>
       <option value=1>是特典</option>
    </select>
-   <select id="setname" name="setname" onchange="changecardselect()">
+   <select id="setname" name="setname">
       <option value="">套卡名</option>
       <option value="初期">初期</option>
       <option value="職業編">职业篇</option>
@@ -2105,9 +1999,9 @@ function calc_bestarm(){
       <option value="サーカス編">马戏团篇</option>
       <option value="妖精の国編">妖精之国篇</option>
    </select>
-   <input type="checkbox" id="showncard" name="showncard" onchange="changecardselect()">显示N卡</input>
+   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel();changecolor('cardchoice')">
+卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
 		<option value=""> </option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>

--- a/templates/llnewcarddata.html
+++ b/templates/llnewcarddata.html
@@ -6,6 +6,7 @@
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.12"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	table {position:relative;margin-left:30px;}
@@ -20,6 +21,8 @@
    var regSand = new RegExp("&amp;", "g")
    var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
+   var llcard = new LLCard(cardsjson);
+
    var attcolor = new Array();
    var language = 0
    var skilllevel = 0
@@ -42,25 +45,6 @@
    cskill['smile'] = "公主"
    cskill['pure'] = "天使"
    cskill['cool'] = "皇后"
-   nametojp = new Array()
-   nametojp["高坂穗乃果"] = "高坂穂乃果"
-   nametojp["绚濑绘里"] = "絢瀬絵里"
-   nametojp["南小鸟"] = "南ことり"
-   nametojp["园田海未"] = "園田海未"
-   nametojp["星空凛"] = "星空凛"
-   nametojp["西木野真姬"] = "西木野真姫"
-   nametojp["东条希"] = "東條希"
-   nametojp["小泉花阳"] = "小泉花陽"
-   nametojp["矢泽妮可"] = "矢澤にこ"
-   nametojp["高海千歌"] = "高海千歌"
-   nametojp["樱内梨子"] = "桜内梨子"
-   nametojp["松浦果南"] = "松浦果南"
-   nametojp["黑泽黛雅"] = "黒澤ダイヤ"
-   nametojp["渡边曜"] = "渡辺曜"
-   nametojp["津岛善子"] = "津島善子"
-   nametojp["国木田花丸"] = "国木田花丸"
-   nametojp["小原鞠莉"] = "小原鞠莉"
-   nametojp["黑泽露比"] = "黒澤ルビィ"
    unitgradechr = [[],
                   ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
                   ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
@@ -77,139 +61,69 @@
 
    var member = ['','1年生','2年生','3年生',"μ's",'Aqours','Printemps','lilywhite','BiBi','CYaRon!','AZALEA','Guilty Kiss']
    
-   function isinunitgroup(unitgrade, character){
-      if (unitgrade == 0)
-         return true
-      for (i in unitgradechr[unitgrade]){
-         if (unitgradechr[unitgrade][i] == character)
-            return true
-      }
-      return false
-   }
-
-   function getcardselect(rarity, chr, att, cardtype,special){
-   	sel = document.getElementById("cardchoice");
-      skilltype = document.getElementById("skilltype").value
-      triggertype = document.getElementById("triggertype").value
-      setname = document.getElementById("setname").value
-      lowbound = document.getElementById("lowbound").value
-      unitgrade = document.getElementById("unitgrade").value
-   	sel.options.length = 1;
-   	var index = 1;
-   	//alert(chr)
-   	for (card in cards){
-   		if (((rarity == "") || (rarity == cards[index].rarity)) && ((chr == "") || (cards[index].jpname.indexOf(nametojp[chr]) != -1)) && ((att == "") || (att == cards[index].attribute)) && ((special == "") || ((cards[index].special == 0) && (special == 0)) || ((cards[index].special == 1) && (special == 1))) && ((cardtype == "") || (cards[index].type.indexOf(cardtype) != -1)) && ((skilltype == "") || (skilltype == cards[index].skilleffect)) && ((triggertype == "") || (triggertype == cards[index].triggertype)) && ((setname == "") || (setname == cards[index].jpseries))){
-            if ((!(document.getElementById('showncard').checked) && (cards[index].rarity == 'N')) || (cards[index].support == 1)){
-               index += 1
-               continue
-            }
-            if ((lowbound != "")){
-               if (parseInt(lowbound) > getmaxstrength(cards[index],1)) {
-                  index += 1
-                  continue
-               }
-            }
-            if (!isinunitgroup(unitgrade, cards[index].jpname)){
-               index += 1
-               continue
-            }
-   			var newOption
-            if (cards[index].eponym) {eponym = "【"+cards[index].eponym+"】"} else eponym = ""
-            if (cards[index].series && (cards[index].series != '')) {series = "("+cards[index].series+")"} else series = ""
-            if (cards[index].jpeponym) {jpeponym = "【"+cards[index].jpeponym+"】"} else jpeponym = ""
-            if (cards[index].jpseries && (cards[index].jpseries != '')) {jpseries = "("+cards[index].jpseries+")"} else jpseries = ""
-   			if (language == 0)
-   				newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+eponym+cards[index].name+" "+series, index)
-   			else
-   				newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+jpeponym+cards[index].jpname+" "+jpseries, index)
-   			newOption.style.color = attcolor[cards[index].attribute]
-   			sel.options.add(newOption)
-   		}
-   		index += 1
-   	}
-   	//changecolor("cardchoice")
-   }
-   
    function changenaipan(){
       if (!document.getElementById('naipan').checked)
          naipan = 26667
       else
          naipan = 15000
-      changecolor('cardchoice')
+      changecolor()
    }
 
    function lvlup(){
       skilllevel += 1
       if (skilllevel == 8)
          skilllevel = 0
-      changecolor('cardchoice')
+      changecolor()
    }
 
    function lvldown(){
       skilllevel -= 1
       if (skilllevel == -1)
          skilllevel = 7
-      changecolor('cardchoice')
+      changecolor()
    }
 
    function slotup(){
       cslot += 1
       if (cslot > maxslot)
          cslot = minslot
-      changecolor('cardchoice')
+      changecolor()
    }
 
    function slotdown(){
       cslot -= 1
       if (cslot < minslot)
          cslot = maxslot
-      changecolor('cardchoice')
+      changecolor()
    }
 
-   function changecardselect(){
-   	rarity = document.getElementById("rarity").value
-   	chr = document.getElementById("chr").value
-   	att = document.getElementById("att").value
-      cardtype = document.getElementById("cardtype").value
-   	special = document.getElementById("special").value
-   	var cardchoice = document.getElementById("cardchoice").value
-   	getcardselect(rarity, chr, att, cardtype, special)
-   	if (havevalue("cardchoice", cardchoice)){
-   		document.getElementById("cardchoice").value = cardchoice
-   	}
-   	changecolor("cardchoice")
-   }
-
-   function getmaxstrength(card, mezame){
-      result = 0
-
-         tmpc = card
-         if (card.smile != 0){
-            sl = slots[card['rarity']][1]
-         }
-         else{
-            sl = slots[card['rarity']][3]
-         }
-         att = tmpc[tmpc.attribute+'2']+kizuna[tmpc.rarity][1]
-         skill = skillstrength(tmpc, 7, 1, 1)
-         if (tmpc.skilleffect == 11){
-            if ((skill*1.5 > att*0.208*1.15) && (sl >= 4))
-               result = parseInt(att*(1+0.052*(sl-4))*1.15+skill*2.5)
-            else
-               result = parseInt(att*(1+0.052*(sl))*1.15+skill)
-         }
-         else if (tmpc.skilleffect == 9){
-            if ((skill*naipan > att*0.208*1.15) && (sl >= 4))
-                  result = parseInt(att*(1+0.052*(sl-4))*1.15+skill*naipan)
-               else
-                  result = parseInt(att*(1+0.052*(sl))*1.15)
-         }
+   function getmaxstrength(card){
+      var result = 0;
+      var slot = slots[card.rarity][(card.smile != 0 ? 1 : 3)];
+      var att = card[card.attribute+'2']+kizuna[card.rarity][1];
+      var skill = 0;
+      if (card.skilldetail !== undefined) {
+         skill = skillstrength(card, 7, 1, 1);
+      }
+      if (card.skilleffect == 11){
+         if ((skill*1.5 > att*0.208*1.15) && (slot >= 4))
+            result = parseInt(att*(1+0.052*(slot-4))*1.15+skill*2.5)
          else
-            result = parseInt(att*(1+0.052*(sl))*1.15)
+            result = parseInt(att*(1+0.052*(slot))*1.15+skill)
+      }
+      else if (card.skilleffect == 9){
+         if ((skill*naipan > att*0.208*1.15) && (slot >= 4))
+            result = parseInt(att*(1+0.052*(slot-4))*1.15+skill*naipan)
+         else
+            result = parseInt(att*(1+0.052*(slot))*1.15)
+      }
+      else
+         result = parseInt(att*(1+0.052*(slot))*1.15)
       return result
    }
 
-   function changecolor(which){
+   function changecolor(){
+      var which = 'cardchoice';
    	document.getElementById("result").style.display = ''
    	index = document.getElementById(which).value
    	if (index != "") {
@@ -315,14 +229,14 @@
          colors = ['smile','pure','cool']
          for (i in colors){
             atttype = colors[i]
-      		if (cards[index].smile != 0){
+            if (cards[index].smile != 0){
                tmpc = cards[index]
                att = tmpc[atttype]
                if (tmpc.attribute != atttype)
                   att /= 1.1
                else
                   att += kizuna[tmpc.rarity][0]
-               skill = skillstrength(tmpc, skilllevel, 1, 1)
+               skill = (tmpc.skilldetail === undefined ? 0 : skillstrength(tmpc, skilllevel, 1, 1));
                if (tmpc.skilleffect == 11){
                   if ((skill*1.5 > att*0.208*1.15) && (minslot >= 4)){
                      document.getElementById(atttype+'strength1').innerHTML = parseInt(att*(1+0.052*(minslot-4))*1.15+skill*2.5)+'<br>(加分宝石)'
@@ -355,14 +269,14 @@
                //document.getElementById('3pstrength1').style.color = attcolor[cards[index].attribute]
       			//document.getElementById('strengthlevel1').innerHTML = strengthlevel(strength(cards[index], 0, skilllevel, 0, 1))
       			//document.getElementById('strengthlevel1').style.color = attcolor[cards[index].attribute]
-      		}
+         }
             tmpc = cards[index]
             att = tmpc[atttype+'2']
             if (tmpc.attribute != atttype)
                   att /= 1.1
                else
                   att += kizuna[tmpc.rarity][1]
-            skill = skillstrength(tmpc, skilllevel, 1, 1)
+            skill = (tmpc.skilldetail === undefined ? 0 : skillstrength(tmpc, skilllevel, 1, 1));
             if (tmpc.skilleffect == 11){
                if ((skill*1.5 > att*0.208*1.15) && (cslot >= 4)){
                   document.getElementById(atttype+'strength2').innerHTML = parseInt(att*(1+0.052*(cslot-4))*1.15+skill*2.5)+'<br>(加分宝石)'
@@ -394,7 +308,7 @@
       		//document.getElementById('strengthlevel2').innerHTML = strengthlevel(strength(cards[index], 1, skilllevel, 0, 1))
       		//document.getElementById('strengthlevel2').style.color = attcolor[cards[index].attribute]
          }
-   	}
+      }
    }
    
    function changeskilleffect(c){
@@ -428,10 +342,9 @@
    }
    
    function changeLanguage(){
-   	var cardchoice = document.getElementById("cardchoice").value
-   	language = 1-language
-	changecardselect()
-   	document.getElementById("cardchoice").value = cardchoice
+      language = 1-language
+      llcard.language = language;
+      llcard.onCardFilterChange();
    }
    
    
@@ -477,25 +390,17 @@
    	return skilldesc
    }
    
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
-   
    function toMezame(){
    	mezame = 1-mezame
-   	changecolor("cardchoice")
+   	changecolor()
    	changeavatarselect()
    }
    
-   
-   
    function init(){
-   	getcardselect("", "", "", "", "" ,"");
+      llcard.onCardSelectChange = changecolor;
+      llcard.calcCardMaxStrength = getmaxstrength;
+      llcard.initListeners();
+      llcard.onCardFilterChange();
    }
    
    </script>
@@ -518,7 +423,7 @@
 
 {% block main %}
 <h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity" onchange="changecardselect()">
+筛选：<select id="rarity" name="rarity">
 		<option value="">稀有度</option>
       <option value="N">N</option>
 		<option value="R">R</option>
@@ -526,7 +431,7 @@
       <option value="SSR">SSR</option>
 		<option value="UR">UR</option>
 	</select>
-	<select id="chr" name="chr" onchange="changecardselect()">
+	<select id="chr" name="chr">
 		<option value="">角色</option>
 		<option value="高坂穗乃果">高坂穗乃果</option>
 		<option value="绚濑绘里">绚濑绘里</option>
@@ -547,7 +452,7 @@
       <option value="小原鞠莉">小原鞠莉</option>
       <option value="黑泽露比">黑泽露比</option>  
 	</select>
-   <select id="unitgrade" name="unitgrade" onchange="changecardselect()">
+   <select id="unitgrade" name="unitgrade">
       <option value="">年级小队</option>
       <option value="4">μ's</option>
       <option value="5">Aqours</option>
@@ -561,13 +466,13 @@
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>
-	<select id="att" name="att" onchange="changecardselect()">
+	<select id="att" name="att">
 		<option value="">属性</option>
 		<option value="smile" style="color:red">smile</option>
 		<option value="pure" style="color:green">pure</option>
 		<option value="cool" style="color:blue">cool</option>
 	</select>
-   <select id="triggertype" name="triggertype" onchange="changecardselect()">
+   <select id="triggertype" name="triggertype">
       <option value="">触发类型</option>
       <option value="1">时间</option>
       <option value="3">图标</option>
@@ -576,24 +481,24 @@
       <option value="6">perfect</option>
       <option value="12">星星perfect</option>
    </select>
-   <select id="skilltype" name="skilltype" onchange="changecardselect()">
+   <select id="skilltype" name="skilltype">
       <option value="">技能类型</option>
       <option value="4">小判定</option>
       <option value="5">大判定</option>
       <option value="9">回血</option>
       <option value="11">加分</option>
    </select>
-   <select id="cardtype" name="cardtype" onchange="changecardselect()">
+   <select id="cardtype" name="cardtype">
       <option value="">卡片类型</option>
       <option value="活动卡">活动卡</option>
       <option value="登录奖励">登录奖励</option>
    </select>
-	<select id="special" name="special" onchange="changecardselect()">
+	<select id="special" name="special">
 		<option value="">是否特典卡</option>
 		<option value=0>不是特典</option>
 		<option value=1>是特典</option>
 	</select>
-   <select id="setname" name="setname" onchange="changecardselect()">
+   <select id="setname" name="setname">
       <option value="">套卡名</option>
       <option value="初期">初期</option>
       <option value="職業編">职业篇</option>
@@ -635,15 +540,15 @@
       <option value="アイドル衣装編">偶像篇</option>
       <option value="小悪魔編">小恶魔篇</option>
    </select><br>
-高级筛选：满槽强度下限 <input type="text" id="lowbound" name="lowbound" autocomplete="off" onchange="changecardselect()" style="width:50px"><br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="cslot=-1;skilllevel=0;changecolor('cardchoice')">
+高级筛选：满槽强度下限 <input type="text" id="lowbound" name="lowbound" autocomplete="off" style="width:50px"><br>
+卡片：<select id="cardchoice" name="cardchoice" onchange="cslot=-1;skilllevel=0">
 		<option value=""> </option>
 	</select>
 	<input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	<br>
-   <input type="checkbox" id="showcard" name="showcard" onchange="changecolor('cardchoice')" checked>显示图片</input>
-   <input type="checkbox" id="smallcard" name="smallcard" onchange="changecolor('cardchoice')" checked>小图</input>
-   <input type="checkbox" id="showncard" name="showncard" onchange="changecardselect()">显示N卡</input>
+   <input type="checkbox" id="showcard" name="showcard" onchange="changecolor()" checked>显示图片</input>
+   <input type="checkbox" id="smallcard" name="smallcard" onchange="changecolor()" checked>小图</input>
+   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <input type="checkbox" id="naipan" name="naipan" onchange="changenaipan()">弱奶判宝石</input>
    <br>
 	

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -7,6 +7,7 @@
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
       img {height:65px;width:65px}
@@ -32,6 +33,7 @@
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
    var llsong = new LLSong(songsjson);
+   var llcard = new LLCard(cardsjson);
 
    var attcolor = new Array();
    var mezame = 0
@@ -45,25 +47,6 @@
    kizuna["SR"] = [250, 500]
    kizuna["SSR"] = [375, 750]
    kizuna["UR"] = [500, 1000]
-   nametojp = new Array()
-   nametojp["高坂穗乃果"] = "高坂穂乃果"
-   nametojp["绚濑绘里"] = "絢瀬絵里"
-   nametojp["南小鸟"] = "南ことり"
-   nametojp["园田海未"] = "園田海未"
-   nametojp["星空凛"] = "星空凛"
-   nametojp["西木野真姬"] = "西木野真姫"
-   nametojp["东条希"] = "東條希"
-   nametojp["小泉花阳"] = "小泉花陽"
-   nametojp["矢泽妮可"] = "矢澤にこ"
-   nametojp["高海千歌"] = "高海千歌"
-   nametojp["樱内梨子"] = "桜内梨子"
-   nametojp["松浦果南"] = "松浦果南"
-   nametojp["黑泽黛雅"] = "黒澤ダイヤ"
-   nametojp["渡边曜"] = "渡辺曜"
-   nametojp["津岛善子"] = "津島善子"
-   nametojp["国木田花丸"] = "国木田花丸"
-   nametojp["小原鞠莉"] = "小原鞠莉"
-   nametojp["黑泽露比"] = "黒澤ルビィ"
    unitgradechr = [[],
                   ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
                   ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
@@ -110,16 +93,6 @@
       changeskilllevel()
    }
 
-   function isinunitgroup(unitgrade, character){
-      if (unitgrade == 0)
-         return true
-      for (i in unitgradechr[unitgrade]){
-         if (unitgradechr[unitgrade][i] == character)
-            return true
-      }
-      return false
-   }
-
    function changeskilllevel(){
       document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
       index = document.getElementById('cardchoice').value
@@ -137,7 +110,6 @@
          naipan = 480
       else
          naipan = 270
-      //changecolor('cardchoice')
    }
 
    pos = -1
@@ -223,68 +195,8 @@
       }
    }
 
-   function getcardselect(rarity, chr, att, cardtype,special){
-      sel = document.getElementById("cardchoice");
-      skilltype = document.getElementById("skilltype").value
-      triggertype = document.getElementById("triggertype").value
-      setname = document.getElementById("setname").value
-      unitgrade = document.getElementById("unitgrade").value
-      sel.options.length = 1;
-      var index = 1;
-      //alert(chr)
-      for (card in cards){
-         if (!cards[index]) continue
-         if (((rarity == "") || (rarity == cards[index].rarity)) && ((chr == "") || (cards[index].jpname.indexOf(nametojp[chr]) != -1)) && ((att == "") || (att == cards[index].attribute)) && ((special == "") || ((cards[index].special == 0) && (special == 0)) || ((cards[index].special == 1) && (special == 1))) && ((cardtype == "") || (cards[index].type.indexOf(cardtype) != -1)) && ((skilltype == "") || (skilltype == cards[index].skilleffect)) && ((triggertype == "") || (triggertype == cards[index].triggertype)) && ((setname == "") || (setname == cards[index].jpseries))){
-            if ((!(document.getElementById('showncard').checked) && (cards[index].rarity == 'N')) || (cards[index].support == 1)){
-               index += 1
-               continue
-            }
-            if (!isinunitgroup(unitgrade, cards[index].jpname)){
-               index += 1
-               continue
-            }
-            var newOption
-            if (cards[index].eponym) {eponym = "【"+cards[index].eponym+"】"} else eponym = ""
-            if (cards[index].series && (cards[index].series != '')) {series = "("+cards[index].series+")"} else series = ""
-            if (cards[index].jpeponym) {jpeponym = "【"+cards[index].jpeponym+"】"} else jpeponym = ""
-            if (cards[index].jpseries && (cards[index].jpseries != '')) {jpseries = "("+cards[index].jpseries+")"} else jpseries = ""
-            if (language == 0)
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+eponym+cards[index].name+" "+series, index)
-            else
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+jpeponym+cards[index].jpname+" "+jpseries, index)
-            newOption.style.color = attcolor[cards[index].attribute]
-            sel.options.add(newOption)
-         }
-         index += 1
-      }
-      //changecolor("cardchoice")
-   }
-
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
-
-   function changecardselect(){
-      var rarity = document.getElementById("rarity").value
-      var chr = document.getElementById("chr").value
-      var att = document.getElementById("att").value
-      var cardtype = document.getElementById("cardtype").value
-      var special = document.getElementById("special").value
-      var cardchoice = document.getElementById("cardchoice").value
-      getcardselect(rarity, chr, att, cardtype, special)
-      if (havevalue("cardchoice", cardchoice)){
-         document.getElementById("cardchoice").value = cardchoice
-      }
-      changecolor("cardchoice")
-   }
-
-   function changecolor(which){
-
+   function changecolor(){
+      var which = 'cardchoice';
    	index = document.getElementById(which).value
    	if (index != "") {
    		c = attcolor[cards[index].attribute]
@@ -299,6 +211,7 @@
             document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
          }
    		infolist2 = ["smile", "pure", "cool"]
+        console.log("mezame=" + mezame);
    		if (mezame == 0){
    			for (i in infolist2){
    				document.getElementById(infolist2[i]).value = cards[index][infolist2[i]]
@@ -399,22 +312,6 @@
       }
    }
 
-   function tothree(string){
-   	str = String(string)
-   	while (str.length < 3){
-   		str = '0'+str
-   	}
-   	return str
-   }
-
-   function carddata(cardid){
-      for (index = 0; index < cards.length; index++){
-         if (cards[index]['id'] == cardid)
-            return cards[index]
-      }
-      return ''
-   }
-
    function changeavatar(n){
       var cardid = threetonumber(document.getElementById('cardid'+String(n)).value)
       if ((cardid == 0) || (cardid == "") || (cardid == "0"))
@@ -439,12 +336,11 @@
    }
 
    function changeLanguage(){
-      var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
       llsong.onSongFilterChange();
-      changecardselect()
-      document.getElementById("cardchoice").value = cardchoice
+      llcard.language = language;
+      llcard.onCardFilterChange();
    }
 
    function changeskilltext(n){
@@ -487,8 +383,7 @@
 
    function toMezame(){
    	mezame = 1-mezame
-   	changecolor("cardchoice")
-   	changeavatarselect()
+   	changecolor()
    }
 
    function clearall(){
@@ -535,8 +430,7 @@
       skilllevel = 0
       mezame = getCookie("mezameunit")
       language = getCookie("languageunit")
-      if (mezame == "")
-         mezame = 0
+      if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
       if (language == "")
          language = 0
 
@@ -545,7 +439,12 @@
       llsong.showAllSongs();
       llsong.initListeners();
       llsong.initAttrSelectColor('map');
-      getcardselect("", "", "", "", "", "");
+
+      llcard.language = language;
+      llcard.onCardSelectChange = changecolor;
+      llcard.showAllCards();
+      llcard.initListeners();
+
       var inputs = document.getElementsByTagName("input");
       var selects = document.getElementsByTagName("select");
       for (var i=0; i<inputs.length; i++) {
@@ -558,10 +457,7 @@
          var curCookie = getCookie(selects[i].name+"unit");
          if (curCookie != "") selects[i].value = curCookie;
       }
-      if (mezame == 1)
-         document.getElementById("mezame").checked = mezame
-      //selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
-      //selects["songchoice"].value = getCookie(selects["songchoice"].name);
+      document.getElementById("mezame").checked = mezame
       try {
          changeskilltext("")
          changeskilllevel()
@@ -575,7 +471,7 @@
          document.getElementById("songsearch").value = ""
          // above codes may select songs/cards/filters according to cookies, so refresh it...
          llsong.onSongFilterChange();
-         changecardselect();
+         llcard.onCardFilterChange();
       } catch (err) {
         console.log(err);
       }
@@ -827,7 +723,7 @@
       }
       //副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
             result['bonusatt'][mapcenter['secondbase']] += Math.ceil(member[i][mapcenter['secondbase']]*mapcenter['secondpercentage']/100)
             if (mapcenter['secondbase'] == mainatt) {
                attst[i] += Math.ceil(rawattst[i]*mapcenter['secondpercentage']/100)
@@ -852,7 +748,7 @@
       }
       //好友副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
             result['bonusatt'][mapcenter['secondbase2']] += Math.ceil(member[i][mapcenter['secondbase2']]*mapcenter['secondpercentage2']/100)
             if (mapcenter['secondbase2'] == mainatt) {
                attst[i] += Math.ceil(rawattst[i]*mapcenter['secondpercentage2']/100)
@@ -1283,7 +1179,7 @@
 	星星perfect数:<input type="number" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
 <h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity" onchange="changecardselect()">
+筛选：<select id="rarity" name="rarity">
       <option value="">稀有度</option>
       <option value="N">N</option>
       <option value="R">R</option>
@@ -1291,7 +1187,7 @@
       <option value="SSR">SSR</option>
       <option value="UR">UR</option>
    </select>
-   <select id="chr" name="chr" onchange="changecardselect()">
+   <select id="chr" name="chr">
       <option value="">角色</option>
       <option value="高坂穗乃果">高坂穗乃果</option>
       <option value="绚濑绘里">绚濑绘里</option>
@@ -1312,7 +1208,7 @@
       <option value="小原鞠莉">小原鞠莉</option>
       <option value="黑泽露比">黑泽露比</option>
    </select>
-   <select id="unitgrade" name="unitgrade" onchange="changecardselect()">
+   <select id="unitgrade" name="unitgrade">
       <option value="">年级小队</option>
       <option value="4">μ's</option>
       <option value="5">Aqours</option>
@@ -1326,13 +1222,13 @@
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>
-   <select id="att" name="att" onchange="changecardselect()">
+   <select id="att" name="att">
       <option value="">属性</option>
       <option value="smile" style="color:red">smile</option>
       <option value="pure" style="color:green">pure</option>
       <option value="cool" style="color:blue">cool</option>
    </select>
-   <select id="triggertype" name="triggertype" onchange="changecardselect()">
+   <select id="triggertype" name="triggertype">
       <option value="">触发类型</option>
       <option value="1">时间</option>
       <option value="3">图标</option>
@@ -1341,24 +1237,24 @@
       <option value="6">perfect</option>
       <option value="12">星星perfect</option>
    </select>
-   <select id="skilltype" name="skilltype" onchange="changecardselect()">
+   <select id="skilltype" name="skilltype">
       <option value="">技能类型</option>
       <option value="4">小判定</option>
       <option value="5">大判定</option>
       <option value="9">回血</option>
       <option value="11">加分</option>
    </select>
-   <select id="cardtype" name="cardtype" onchange="changecardselect()">
+   <select id="cardtype" name="cardtype">
       <option value="">卡片类型</option>
       <option value="活动卡">活动卡</option>
       <option value="登录奖励">登录奖励</option>
    </select>
-   <select id="special" name="special" onchange="changecardselect()">
+   <select id="special" name="special">
       <option value="">是否特典卡</option>
       <option value=0>不是特典</option>
       <option value=1>是特典</option>
    </select>
-   <select id="setname" name="setname" onchange="changecardselect()">
+   <select id="setname" name="setname">
       <option value="">套卡名</option>
       <option value="初期">初期</option>
       <option value="職業編">职业篇</option>
@@ -1395,9 +1291,9 @@
       <option value="サーカス編">马戏团篇</option>
       <option value="妖精の国編">妖精之国篇</option>
    </select>
-   <input type="checkbox" id="showncard" name="showncard" onchange="changecardselect()">显示N卡</input>
+   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel();changecolor('cardchoice')">
+卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
 		<option value=""> </option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -7,6 +7,7 @@
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -22,6 +23,7 @@
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var cards = eval("("+cardsjson+")")
    var llsong = new LLSong(songsjson);
+   var llcard = new LLCard(cardsjson);
 
    var attcolor = new Array();
    var mezame = 0
@@ -36,25 +38,6 @@
    kizuna["SR"] = [250, 500]
    kizuna["SSR"] = [375, 750]
    kizuna["UR"] = [500, 1000]
-   nametojp = new Array()
-   nametojp["高坂穗乃果"] = "高坂穂乃果"
-   nametojp["绚濑绘里"] = "絢瀬絵里"
-   nametojp["南小鸟"] = "南ことり"
-   nametojp["园田海未"] = "園田海未"
-   nametojp["星空凛"] = "星空凛"
-   nametojp["西木野真姬"] = "西木野真姫"
-   nametojp["东条希"] = "東條希"
-   nametojp["小泉花阳"] = "小泉花陽"
-   nametojp["矢泽妮可"] = "矢澤にこ"
-   nametojp["高海千歌"] = "高海千歌"
-   nametojp["樱内梨子"] = "桜内梨子"
-   nametojp["松浦果南"] = "松浦果南"
-   nametojp["黑泽黛雅"] = "黒澤ダイヤ"
-   nametojp["渡边曜"] = "渡辺曜"
-   nametojp["津岛善子"] = "津島善子"
-   nametojp["国木田花丸"] = "国木田花丸"
-   nametojp["小原鞠莉"] = "小原鞠莉"
-   nametojp["黑泽露比"] = "黒澤ルビィ"
    unitgradechr = [[],
                   ["星空凛","西木野真姫","小泉花陽","津島善子","国木田花丸","黒澤ルビィ"],
                   ["高坂穂乃果","南ことり","園田海未","高海千歌","桜内梨子","渡辺曜"],
@@ -120,16 +103,6 @@
       changeskilllevel()
    }
 
-   function isinunitgroup(unitgrade, character){
-      if (unitgrade == 0)
-         return true
-      for (i in unitgradechr[unitgrade]){
-         if (unitgradechr[unitgrade][i] == character)
-            return true
-      }
-      return false
-   }
-
    function changeskilllevel(){
       document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
       index = document.getElementById('cardchoice').value
@@ -147,7 +120,6 @@
          naipan = 480
       else
          naipan = 270
-      //changecolor('cardchoice')
    }
 
    pos = -1
@@ -233,67 +205,8 @@
       }
    }
 
-   function getcardselect(rarity, chr, att, cardtype,special){
-      sel = document.getElementById("cardchoice");
-      skilltype = document.getElementById("skilltype").value
-      triggertype = document.getElementById("triggertype").value
-      setname = document.getElementById("setname").value
-      unitgrade = document.getElementById("unitgrade").value
-      sel.options.length = 1;
-      var index = 1;
-      //alert(chr)
-      for (card in cards){
-         if (!cards[index]) continue
-         if (((rarity == "") || (rarity == cards[index].rarity)) && ((chr == "") || (cards[index].jpname.indexOf(nametojp[chr]) != -1)) && ((att == "") || (att == cards[index].attribute)) && ((special == "") || ((cards[index].special == 0) && (special == 0)) || ((cards[index].special == 1) && (special == 1))) && ((cardtype == "") || (cards[index].type.indexOf(cardtype) != -1)) && ((skilltype == "") || (skilltype == cards[index].skilleffect)) && ((triggertype == "") || (triggertype == cards[index].triggertype)) && ((setname == "") || (setname == cards[index].jpseries))){
-            if ((!(document.getElementById('showncard').checked) && (cards[index].rarity == 'N')) || (cards[index].support == 1)){
-               index += 1
-               continue
-            }
-            if (!isinunitgroup(unitgrade, cards[index].jpname)){
-               index += 1
-               continue
-            }
-            var newOption
-            if (cards[index].eponym) {eponym = "【"+cards[index].eponym+"】"} else eponym = ""
-            if (cards[index].series && (cards[index].series != '')) {series = "("+cards[index].series+")"} else series = ""
-            if (cards[index].jpeponym) {jpeponym = "【"+cards[index].jpeponym+"】"} else jpeponym = ""
-            if (cards[index].jpseries && (cards[index].jpseries != '')) {jpseries = "("+cards[index].jpseries+")"} else jpseries = ""
-            if (language == 0)
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+eponym+cards[index].name+" "+series, index)
-            else
-               newOption = new Option(tothree(cards[index].id)+" "+cards[index].rarity+" "+jpeponym+cards[index].jpname+" "+jpseries, index)
-            newOption.style.color = attcolor[cards[index].attribute]
-            sel.options.add(newOption)
-         }
-         index += 1
-      }
-      //changecolor("cardchoice")
-   }
-   
-   function havevalue(selectId, value){
-   	objSelect = document.getElementById(selectId)
-   	for (var i = 0; i < objSelect.options.length; i++){
-   		if (objSelect.options[i].value == value)
-   			return true;
-   	}
-   	return false;
-   }
-   
-   function changecardselect(){
-      rarity = document.getElementById("rarity").value
-      chr = document.getElementById("chr").value
-      att = document.getElementById("att").value
-      cardtype = document.getElementById("cardtype").value
-      special = document.getElementById("special").value
-      var cardchoice = document.getElementById("cardchoice").value
-      getcardselect(rarity, chr, att, cardtype, special)
-      if (havevalue("cardchoice", cardchoice)){
-         document.getElementById("cardchoice").value = cardchoice
-      }
-      changecolor("cardchoice")
-   }
-   
-   function changecolor(which){
+   function changecolor(){
+      var which = "cardchoice";
 
    	index = document.getElementById(which).value
    	if (index != "") {
@@ -422,22 +335,6 @@
       }
    }
    
-   function tothree(string){
-   	str = String(string)
-   	while (str.length < 3){
-   		str = '0'+str
-   	}
-   	return str
-   }
-   
-   function carddata(cardid){
-      for (index = 0; index < cards.length; index++){
-         if (cards[index]['id'] == cardid)
-            return cards[index]
-      }
-      return ''
-   }
-
    function changeavatar(n){
    	cardid = threetonumber(document.getElementById('cardid'+String(n)).value)
    	if ((cardid == 0) || (cardid == "") || (cardid == "0"))
@@ -463,12 +360,11 @@
    }
    
    function changeLanguage(){
-      var cardchoice = document.getElementById("cardchoice").value
       language = 1-language
       llsong.language = language;
       llsong.onSongFilterChange();
-      changecardselect()
-      document.getElementById("cardchoice").value = cardchoice
+      llcard.language = language;
+      llcard.onCardFilterChange();
    }
    
    function changeskilltext(n){
@@ -511,11 +407,8 @@
    
    function toMezame(){
    	mezame = 1-mezame
-   	changecolor("cardchoice")
-   	changeavatarselect()
+   	changecolor()
    }
-   
-   
 
 
    function clearall(){
@@ -562,8 +455,7 @@
       skilllevel = 0
       mezame = getCookie("mezameunit")
       language = getCookie("languageunit")
-      if (mezame == "")
-         mezame = 0
+      if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
       if (language == "")
          language = 0
 
@@ -572,7 +464,11 @@
       llsong.showAllSongs();
       llsong.initListeners();
       llsong.initAttrSelectColor('map');
-   	getcardselect("", "", "", "", "", "");
+
+      llcard.language = language;
+      llcard.onCardSelectChange = changecolor;
+      llcard.showAllCards();
+      llcard.initListeners();
    	var inputs = document.getElementsByTagName("input");
    	var selects = document.getElementsByTagName("select");
    	for (var i=0; i<inputs.length; i++){
@@ -584,10 +480,7 @@
    		if (getCookie(selects[i].name+"unit") != "")
    			selects[i].value = getCookie(selects[i].name+"unit");
    	}
-   	if (mezame == 1)
-   		document.getElementById("mezame").checked = mezame
-   	//selects["cardchoice"].value = getCookie(selects["cardchoice"].name);
-   	//selects["songchoice"].value = getCookie(selects["songchoice"].name);
+      document.getElementById("mezame").checked = mezame
       try {
    	changeskilltext("")
       changeskilllevel()
@@ -601,7 +494,7 @@
          document.getElementById("songsearch").value = ""
          // above codes may select songs/cards/filters according to cookies, so refresh it...
          llsong.onSongFilterChange();
-         changecardselect();
+         llcard.onCardFilterChange();
       } catch (err) {}
 
       {{additional_script|safe}}
@@ -1187,7 +1080,7 @@ function calc_bestarm(){
       }
       //副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit'], cards[member[i]["cardid"]]["jpname"])){
 		 ////////////////////
 		if(Precal&&(mapcenter['bonus']==mainatt)) Match_c[i]+=(mapcenter['secondpercentage']/100);
 		//////////////////////
@@ -1217,7 +1110,7 @@ function calc_bestarm(){
       }
       //好友副c技能
       for (var i = 0; i < 9; i++) {
-         if (isinunitgroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
+         if (llcard.isInUnitGroup(mapcenter['secondlimit2'], cards[member[i]["cardid"]]["jpname"])){
 		 ////////////////////
 		if(Precal &&(mapcenter['bonus2']==mainatt))
 		 Match_c[i]+=(mapcenter['secondpercentage2']/100);
@@ -1611,7 +1504,7 @@ function calc_bestarm(){
 	星星perfect数:<input type="text" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
 <h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity" onchange="changecardselect()">
+筛选：<select id="rarity" name="rarity">
       <option value="">稀有度</option>
       <option value="N">N</option>
       <option value="R">R</option>
@@ -1619,7 +1512,7 @@ function calc_bestarm(){
       <option value="SSR">SSR</option>
       <option value="UR">UR</option>
    </select>
-   <select id="chr" name="chr" onchange="changecardselect()">
+   <select id="chr" name="chr">
       <option value="">角色</option>
       <option value="高坂穗乃果">高坂穗乃果</option>
       <option value="绚濑绘里">绚濑绘里</option>
@@ -1640,7 +1533,7 @@ function calc_bestarm(){
       <option value="小原鞠莉">小原鞠莉</option>
       <option value="黑泽露比">黑泽露比</option>
    </select>
-   <select id="unitgrade" name="unitgrade" onchange="changecardselect()">
+   <select id="unitgrade" name="unitgrade">
       <option value="">年级小队</option>
       <option value="4">μ's</option>
       <option value="5">Aqours</option>
@@ -1654,13 +1547,13 @@ function calc_bestarm(){
       <option value="10">AZALEA</option>
       <option value="11">Guilty Kiss</option>
    </select>
-   <select id="att" name="att" onchange="changecardselect()">
+   <select id="att" name="att">
       <option value="">属性</option>
       <option value="smile" style="color:red">smile</option>
       <option value="pure" style="color:green">pure</option>
       <option value="cool" style="color:blue">cool</option>
    </select>
-   <select id="triggertype" name="triggertype" onchange="changecardselect()">
+   <select id="triggertype" name="triggertype">
       <option value="">触发类型</option>
       <option value="1">时间</option>
       <option value="3">图标</option>
@@ -1669,24 +1562,24 @@ function calc_bestarm(){
       <option value="6">perfect</option>
       <option value="12">星星perfect</option>
    </select>
-   <select id="skilltype" name="skilltype" onchange="changecardselect()">
+   <select id="skilltype" name="skilltype">
       <option value="">技能类型</option>
       <option value="4">小判定</option>
       <option value="5">大判定</option>
       <option value="9">回血</option>
       <option value="11">加分</option>
    </select>
-   <select id="cardtype" name="cardtype" onchange="changecardselect()">
+   <select id="cardtype" name="cardtype">
       <option value="">卡片类型</option>
       <option value="活动卡">活动卡</option>
       <option value="登录奖励">登录奖励</option>
    </select>
-   <select id="special" name="special" onchange="changecardselect()">
+   <select id="special" name="special">
       <option value="">是否特典卡</option>
       <option value=0>不是特典</option>
       <option value=1>是特典</option>
    </select>
-   <select id="setname" name="setname" onchange="changecardselect()">
+   <select id="setname" name="setname">
       <option value="">套卡名</option>
       <option value="初期">初期</option>
       <option value="職業編">职业篇</option>
@@ -1723,9 +1616,9 @@ function calc_bestarm(){
       <option value="サーカス編">马戏团篇</option>
       <option value="妖精の国編">妖精之国篇</option>
    </select>
-   <input type="checkbox" id="showncard" name="showncard" onchange="changecardselect()">显示N卡</input>
+   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel();changecolor('cardchoice')">
+卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
 		<option value=""> </option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>


### PR DESCRIPTION
Fixes:
* Fix mezame checkbox on page refresh
![pr3-before-mezame-fix](https://user-images.githubusercontent.com/17180510/36735016-2282278c-1c10-11e8-9fc8-45ff2b873144.png)
* Fix exception in skill strength calculation in llnewcarddata
Before fix:
![pr3-before-llnewcarddata-fix](https://user-images.githubusercontent.com/17180510/36735040-2fba3eda-1c10-11e8-915e-bc17ba643ddf.png)
After fix:
![pr3-after-llnewcarddata-fix](https://user-images.githubusercontent.com/17180510/36735085-50e4e272-1c10-11e8-9293-dfbdc1de37d1.png)

Enhancement for developer:
* Unified and moved card filter/select logic to `llcard.js`, reuse in `llcoverage`, `llnewautounit`, `llnewcarddata`, `llnewunit`, `llnewunitsis`
