### PR TITLE
Implement card data query on backend and update llnewunit to query card data on demand

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,10 +5,14 @@ from flask import Flask, render_template, redirect, session, request, send_file
 import string
 import random
 import json
+from lldata import LLData
 
 app = Flask(__name__)
 app.secret_key = "hatsune miku"
 app.debug = True
+
+g_llcarddata = LLData()
+g_llcarddata.loadJson('newcardsjson.txt')
 
 ### activity ###
 @app.route("/activitypt")
@@ -75,6 +79,16 @@ def llnewcarddata():
 def llurcardrank():
     cardsjson = open('newcardsjson.txt', 'rb').read()
     return render_template('llurcardrank.html', cardsjson = cardsjson)
+
+@app.route("/lldata/cardbrief", methods=['GET'])
+def lldata_cardbrief():
+    print request.args
+    return json.dumps(g_llcarddata.queryByKeys(request.args['keys']))
+
+@app.route("/lldata/card/<index>", methods=['GET'])
+def lldata_carddetail(index):
+    print index
+    return json.dumps(g_llcarddata.queryByIndex(index))
 
 ### data api ###
 @app.route("/llcardapiwiki")

--- a/lldata.py
+++ b/lldata.py
@@ -1,0 +1,26 @@
+import json
+
+class LLData:
+    def __init__(self):
+        self.data = {}
+
+    def loadJson(self, jsonfile):
+        jsonstr = open(jsonfile, 'rb').read()
+        self.data = json.loads(jsonstr)
+
+    def queryByKeys(self, keys):
+        ret = {}
+        keylist = keys.split(',')
+        for index, data in self.data.iteritems():
+            outdata = {}
+            for key in keylist:
+                if key in data:
+                    outdata[key] = data[key]
+            ret[index] = outdata
+        return ret
+
+    def queryByIndex(self, index):
+        if index in self.data:
+            return self.data[index];
+        return {};
+

--- a/llunit.py
+++ b/llunit.py
@@ -41,6 +41,12 @@ def llsaveallmembers(content):
     response.headers['Content-Disposition']='attachment; filename=submembers.sd'
     return response
 
+@app.route("/llload/<callback>", methods=['GET', 'POST'])
+def llload(callback):
+    print request.files, callback
+    for f in request.files['file']:
+        return '<script>' + callback + '(' + f.replace('%7B', '{').replace('%22', '"').replace('%7D', '}').replace('%5B', '[').replace('%5D', ']') + ');</script>'
+
 @app.route("/llloadnewsubmemberssis", methods=['GET', 'POST'])
 def llnewsubmembersload():
     print request.files

--- a/static/lldata.js
+++ b/static/lldata.js
@@ -1,0 +1,101 @@
+/*
+ * script to load song/card data
+ * require jQuery
+ *
+ * By ben1222
+ */
+
+function LLData(brief_url, detail_url, brief_keys) {
+   this.briefUrl = brief_url;
+   this.detailUrl = detail_url;
+   this.briefKeys = brief_keys;
+   this.briefCache = {};
+   this.briefCachedKeys = {};
+   this.detailCache = {};
+}
+
+LLData.prototype.getAllBriefData = function(keys, url) {
+   if (keys === undefined) keys = this.briefKeys;
+   if (url === undefined) url = this.briefUrl;
+   var me = this;
+   var missingKeys = [];
+   var defer = $.Deferred();
+   for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      if (!this.briefCachedKeys[key]) {
+         missingKeys.push(key);
+      }
+   }
+   if (missingKeys.length == 0) {
+      defer.resolve(me.briefCache);
+      return defer;
+   }
+   var requestKeys = missingKeys.sort().join(',');
+
+   $.ajax({
+      'url': url,
+      'type': 'GET',
+      'data': {
+         'keys': requestKeys
+      },
+      'success': function (data) {
+         for (var index in data) {
+            if (!me.briefCache[index]) {
+               me.briefCache[index] = data[index];
+            } else {
+               var curData = data[index];
+               var curCache = me.briefCache[index];
+               for (var curKey in curData) {
+                  curCache[curKey] = curData[curKey];
+               }
+            }
+         }
+         for (var i = 0; i < missingKeys.length; i++) {
+            me.briefCachedKeys[missingKeys[i]] = 1;
+         }
+         defer.resolve(me.briefCache);
+      },
+      'error': function (xhr, textStatus, errorThrown) {
+         console.error("Failed on request to " + url + " with keys:\"" + requestKeys + "\": " + textStatus);
+         console.error(errorThrown);
+         defer.reject();
+      },
+      'dataType': 'json'
+   });
+   return defer;
+};
+
+LLData.prototype.getDetailedData = function(index, url) {
+   if (url === undefined) url = this.detailUrl;
+   var defer = $.Deferred();
+   if (index === undefined) {
+      console.error("Index not specified");
+      defer.reject();
+      return defer;
+   }
+   if (this.detailCache[index]) {
+      defer.resolve(this.detailCache[index]);
+      return defer;
+   }
+   var me = this;
+   url = url + index;
+   $.ajax({
+      'url': url ,
+      'type': 'GET',
+      'success': function (data) {
+         me.detailCache[index] = data;
+         defer.resolve(data);
+      },
+      'error': function (xhr, textStatus, errorThrown) {
+         console.error("Failed on request to " + url + ": " + textStatus);
+         console.error(errorThrown);
+         defer.reject();
+      },
+      'dataType': 'json'
+   });
+   return defer;
+};
+
+var LLCardData = new LLData('/lldata/cardbrief', '/lldata/card/',
+   ['id', 'support', 'rarity', 'jpname', 'name', 'attribute', 'special', 'type', 'skilleffect', 'triggertype', 'jpseries', 'series', 'eponym', 'jpeponym']);
+

--- a/static/llnewunit/storage.js
+++ b/static/llnewunit/storage.js
@@ -4,6 +4,19 @@
 
   function loadUnitFromJSON(json) {
     console.log(json);
+    var member = JSON.parse(json);
+    var attlist = ['smile', 'pure', 'cool', 'skilllevel', 'cardid', 'mezame', 'gemnum', 'gemsinglepercent', 'gemallpercent', 'gemskill', 'gemacc']
+    for (var i = 0; i < 9; i++) {
+      for (var j in attlist) {
+        var att = attlist[j];
+        document.getElementById(att + i).value = member[i][att];
+      }
+      document.getElementById('main' + i).value = llcard.cards[member[i]['cardid']].attribute;
+      changeavatar(i);
+      calslot(i);
+    }
+    changecenter();
+    /*
     $.ajax({
       url: '/llloadnewunit-api',
       type: 'POST',
@@ -15,6 +28,7 @@
       },
       contentType: 'application/json',
     });
+    */
   }
 
   function readUnitJSON(name) {

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -8,6 +8,7 @@
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llcard.js') }}"></script>
+   <script type="text/javascript" src="{{ url_for('static', filename='lldata.js') }}"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
       img {height:65px;width:65px}
@@ -29,11 +30,13 @@
    var regS = new RegExp("&#34;", "g")
    var regS2 = new RegExp("&#39;", "g")
    var regSand = new RegExp("&amp;", "g")
-   var cardsjson = "{{cardsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
    var songsjson = "{{songsjson}}".replace(regS,'"').replace(regS2, "'").replace(regSand, '&')
-   var cards = eval("("+cardsjson+")")
    var llsong = new LLSong(songsjson);
-   var llcard = new LLCard(cardsjson);
+   var llcard = 0;
+   //var llcard = new LLCard(cardsjson);
+   var handleFailedRequest = function() {
+      alert('载入失败!');
+   };
 
    var attcolor = new Array();
    var mezame = 0
@@ -64,6 +67,13 @@
    var member = ['','1年生','2年生','3年生',"μ's",'Aqours','Printemps','lilywhite','BiBi','CYaRon!','AZALEA','Guilty Kiss']
 
    var skilllevel = 0
+
+   var defer_onload = $.Deferred();
+   $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
+      llcard = new LLCard(cardData);
+      init();
+      document.getElementById('cardchoice').options[0].innerHTML = '';
+   }, handleFailedRequest);
 
    function threetonumber(three){
       var result = three
@@ -139,21 +149,11 @@
       index = document.getElementById('cardid'+String(n)).value
       level = parseInt(document.getElementById('skilllevel'+String(n)).value)-1
       if ((level < 0) || (level > 7)) return
-      document.getElementById('require'+String(n)).value = cards[index]['skilldetail'][level].require
-      document.getElementById('possibility'+String(n)).value = cards[index]['skilldetail'][level].possibility
-      document.getElementById('score'+String(n)).value = cards[index]['skilldetail'][level].score
-   }
-
-   function getskilllevel(n){
-
-      score = document.getElementById('score'+String(n)).value
-      index = threetonumber(document.getElementById('cardid'+String(n)).value)
-      if (!cards[index].skill) return 0
-      for (i=0;i<8;i++){
-         if (cards[index]['skilldetail'][i].score == score)
-            return i+1
-      }
-      return 0
+      LLCardData.getDetailedData(index).then(function(card) {
+         document.getElementById('require'+String(n)).value = card['skilldetail'][level].require
+         document.getElementById('possibility'+String(n)).value = card['skilldetail'][level].possibility
+         document.getElementById('score'+String(n)).value = card['skilldetail'][level].score
+      }, handleFailedRequest);
    }
 
    function cardtoskilltype(c){
@@ -196,38 +196,38 @@
    }
 
    function changecolor(){
-      var which = 'cardchoice';
-   	index = document.getElementById(which).value
-   	if (index != "") {
-   		c = attcolor[cards[index].attribute]
-   		document.getElementById(which).style.color = c
-   		document.getElementById("main").value = cards[index].attribute
+      var index = document.getElementById('cardchoice').value;
+      if (index != "") {
+         LLCardData.getDetailedData(index).then(function(card) {
+            var c = llcard.attcolor[card.attribute];
+            document.getElementById('cardchoice').style.color = c
+            document.getElementById("main").value = card.attribute
 
-         //document.getElementById('skill').value = cardtoskilltype(cards[index])
-         if (cards[index].skill){
-            //skilllevel = parseInt(document.getElementById('skilllevel').innerHTML)
-            document.getElementById('require').innerHTML = cards[index]['skilldetail'][skilllevel].require
-            document.getElementById('possibility').innerHTML = cards[index]['skilldetail'][skilllevel].possibility
-            document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
-         }
-   		infolist2 = ["smile", "pure", "cool"]
-        console.log("mezame=" + mezame);
-   		if (mezame == 0){
-   			for (i in infolist2){
-   				document.getElementById(infolist2[i]).value = cards[index][infolist2[i]]
-   				document.getElementById("mezame").value = "未觉醒"
-   			}
-   		}
-   		else{
-   			for (i in infolist2){
-   				document.getElementById(infolist2[i]).value = cards[index][infolist2[i]+"2"]
-   				document.getElementById("mezame").value = "已觉醒"
-   			}
-   		}
-   		document.getElementById("kizuna").value = kizuna[cards[index].rarity][mezame]
-   		changeskilltext("")
-   	}
-   	changeavatarselect()
+            //document.getElementById('skill').value = cardtoskilltype(card)
+            if (card.skill){
+               //skilllevel = parseInt(document.getElementById('skilllevel').innerHTML)
+               document.getElementById('require').innerHTML = card['skilldetail'][skilllevel].require
+               document.getElementById('possibility').innerHTML = card['skilldetail'][skilllevel].possibility
+               document.getElementById('score').innerHTML = card['skilldetail'][skilllevel].score
+            }
+            var infolist2 = ["smile", "pure", "cool"]
+            if (mezame == 0){
+               for (var i in infolist2){
+                  document.getElementById(infolist2[i]).value = card[infolist2[i]]
+               }
+               document.getElementById("mezame").value = "未觉醒"
+            }
+            else{
+               for (var i in infolist2){
+                  document.getElementById(infolist2[i]).value = card[infolist2[i]+"2"]
+               }
+               document.getElementById("mezame").value = "已觉醒"
+            }
+            document.getElementById("kizuna").value = kizuna[card.rarity][mezame]
+            changeskilltext(card, "")
+         }, handleFailedRequest);
+      }
+      changeavatarselect(index)
    }
 
    function changemapcolor(attr) {
@@ -255,15 +255,6 @@
       llsong.applyDataOfSongWithDiff(applyTarget);
    }
 
-   function cardidtoindex(n){
-   	cardid = parseInt(n)
-   	for (i in cards){
-   		if (cards[i].id == n){
-   			return i
-   		}
-   	}
-   }
-
    function calslot(n){
       result = 0
       result += parseInt(parseInt(document.getElementById("gemnum"+String(n)).value)/200)
@@ -284,7 +275,7 @@
    	}
       document.getElementById("skilllevel"+String(n)).value = document.getElementById('skilllevel').innerHTML
    	document.getElementById("mezame"+String(n)).value = mezame
-   	document.getElementById("cardid"+String(n)).value = cards[String(document.getElementById("cardchoice").value)].id
+   	document.getElementById("cardid"+String(n)).value = document.getElementById("cardchoice").value
    	//changeskilltext(n)
    	if (n == 4){
    		changecenter()
@@ -293,23 +284,18 @@
    }
 
    function changecenter(){
-   	cardid = parseInt(document.getElementById("cardid4").value)
-   	index = 0
-   	for (i in cards){
-   		if (cards[i].id == cardid){
-   			index = i
-   			break
-   		}
-   	}
-   	document.getElementById("bonus").value = cards[index]["attribute"]
-   	document.getElementById("percentage").value = cards[index]["Cskillpercentage"]
-   	document.getElementById("base").value = cards[index]["Cskillattribute"]
-      document.getElementById("secondpercentage").value = "0"
-      if (cards[index]["rarity"] == "SSR" || cards[index]["rarity"] == "UR"){
-         document.getElementById("secondlimit").value = cards[index]["Csecondskilllimit"]
-         //document.getElementById("secondbase").innerHTML = cards[index]["attribute"]
-         document.getElementById("secondpercentage").value = cards[index]["Csecondskillattribute"]
-      }
+      var cardid = parseInt(document.getElementById("cardid4").value)
+      LLCardData.getDetailedData(cardid).then(function(card) {
+         document.getElementById("bonus").value = card["attribute"]
+         document.getElementById("percentage").value = card["Cskillpercentage"]
+         document.getElementById("base").value = card["Cskillattribute"]
+         document.getElementById("secondpercentage").value = "0"
+         if (card["rarity"] == "SSR" || card["rarity"] == "UR"){
+            document.getElementById("secondlimit").value = card["Csecondskilllimit"]
+            //document.getElementById("secondbase").innerHTML = card["attribute"]
+            document.getElementById("secondpercentage").value = card["Csecondskillattribute"]
+         }
+      }, handleFailedRequest);
    }
 
    function changeavatar(n){
@@ -317,22 +303,19 @@
       if ((cardid == 0) || (cardid == "") || (cardid == "0"))
          document.getElementById('avatar'+String(n)).src = '/static/null.png'
       else if (document.getElementById('mezame'+String(n)).value == 0)
-         document.getElementById('avatar'+String(n)).src = getimagepath(cards[cardid]['id'],'avatar',0)
+         document.getElementById('avatar'+String(n)).src = getimagepath(cardid,'avatar',0)
       else
-         document.getElementById('avatar'+String(n)).src = getimagepath(cards[cardid]['id'],'avatar',1)
+         document.getElementById('avatar'+String(n)).src = getimagepath(cardid,'avatar',1)
    }
 
-   function changeavatarselect(){
+   function changeavatarselect(cardid){
    	document.getElementById('imageselect').src = '/static/null.png'
-   	cardid = 0
-   	if (document.getElementById('cardchoice').value != '')
-   		cardid = cards[document.getElementById('cardchoice').value].id
    	if ((cardid == 0) || (cardid == "") || (cardid == "0"))
    		document.getElementById('imageselect').src = '/static/null.png'
    	else if (mezame == 0)
-   		document.getElementById('imageselect').src = getimagepath(cards[document.getElementById('cardchoice').value]['id'],'avatar',0)
+   		document.getElementById('imageselect').src = getimagepath(cardid,'avatar',0)
    	else
-   		document.getElementById('imageselect').src = getimagepath(cards[document.getElementById('cardchoice').value]['id'],'avatar',1)
+   		document.getElementById('imageselect').src = getimagepath(cardid,'avatar',1)
    }
 
    function changeLanguage(){
@@ -343,11 +326,11 @@
       llcard.onCardFilterChange();
    }
 
-   function changeskilltext(n){
+   function changeskilltext(card, n){
    	var postfix = ""
    	if ((n != "") || (String(n) == "0"))
    		postfix = String(n)
-      var skilltype = cardtoskilltype(cards[document.getElementById("cardchoice").value])
+      var skilltype = cardtoskilltype(card)
    	//var skilltype = document.getElementById("skill"+postfix).value
    	//if (skilltype == 0)
    	//	document.getElementById("skilltext"+postfix).style.display = "none"
@@ -479,9 +462,9 @@
       }
       document.getElementById("mezame").checked = mezame
       try {
-         changeskilltext("")
+         //changeskilltext("")
          changeskilllevel()
-         changeavatarselect()
+         //changeavatarselect()
          for (i = 0; i < 9; i++){
             //changeskilltext(i)
             changeavatar(i)
@@ -623,6 +606,24 @@
    }
 
    function calculate() {
+      var unitCardData = {};
+      var finishedCount = 0;
+      var defer_carddata = $.Deferred();
+      for (var i = 0; i < 9; i++) {
+         var cardid = document.getElementById('cardid' + i).value;
+         LLCardData.getDetailedData(cardid).then(function(card) {
+            // do not use cardid, as its value can change...
+            unitCardData[parseInt(card.id)] = card;
+            finishedCount++;
+            if (finishedCount == 9) defer_carddata.resolve(unitCardData);
+         }, function() {
+            defer_carddata.reject();
+         });
+      }
+      defer_carddata.then(docalculate, handleFailedRequest);
+   }
+
+   function docalculate(cards) {
       var result = {};
       var int_element = ["cardid", "smile", "pure", "cool", "skilllevel", 'gemnum', 'gemskill', 'gemacc'];
       var float_element = ["weight",'gemsinglepercent','gemallpercent'];
@@ -1119,11 +1120,6 @@
                   default: return 0.00
             }
       }
-      var cardTypes = []
-      for (var currCardId in cards) {
-            var currCard = cards[currCardId]
-            if (cardTypes.indexOf(currCard.type) === -1) cardTypes.push(currCard.type)
-      }
       var micRawValue = member.reduce(function (sum, currMember) {
             return sum + currMember.skilllevel * getRarityRatio(currMember)
       }, 0.00)
@@ -1141,7 +1137,7 @@
 {% endblock %}
 
 {% block body_onload %}
-   <body onload="init()" lang="zh-Hans">
+   <body onload="defer_onload.resolve()" lang="zh-Hans">
 {% endblock %}
 
 {% block front_notice %}
@@ -1314,7 +1310,7 @@
    <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <br>
 卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
-		<option value=""> </option>
+		<option value="">载入中...</option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
 	（特典卡需选择觉醒）<br>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -411,12 +411,32 @@
    	window.location.href="/llsaveunit/"+unitjson
    }
 
+   function handleLoadUnit(unit) {
+      var attlist = ['smile', 'pure', 'cool', 'skilllevel', 'cardid', 'mezame', 'gemnum', 'gemsinglepercent', 'gemallpercent', 'gemskill', 'gemacc'];
+      for (var i = 0; i < 9; i++) {
+         var member = unit[i];
+         for (var j in attlist) {
+            var att = attlist[j];
+            var value = 0;
+            if (member && member[att] !== undefined) value = member[att];
+            document.getElementById(att + i).value = value;
+         }
+         if (member && member.cardid) {
+            document.getElementById("main" + i).value = llcard.cards[member.cardid].attribute;
+         }
+         changeavatar(i);
+         calslot(i);
+      }
+      changecenter();
+      precalcu();
+   }
+
    var tmponsubmit
    function loadunit(){
-   	document.getElementById("unitform").action = '/llloadnewunit'
-   	tmponsubmit = document.getElementById("unitform").onsubmit
-   	document.getElementById("unitform").onsubmit = ''
-   	document.getElementById("unitform").target = 'if'
+      document.getElementById("unitform").action = '/llload/parent.handleLoadUnit'
+      tmponsubmit = document.getElementById("unitform").onsubmit
+      document.getElementById("unitform").onsubmit = ''
+      document.getElementById("unitform").target = 'if'
    }
 
    function precalcu(){


### PR DESCRIPTION
New features:
* The backend now support query card data using `/lldata/cardbrief?keys=<key1>,<key2>,...<keyn>` and `/lldata/card/<cardid>`
* `llnewunit` page now load card data on demand, the html size reduced from 2.6MB to 820KB, the queried card brief data is about 410KB
![pr4-lazyload](https://user-images.githubusercontent.com/17180510/36739503-0eb1db20-1c1b-11e8-8c72-4399f16af644.png)

Enhancement for developer:
* Now for `llnewunit`, load unit from file will process the file data in webpage, not need server to build and send javascript - the server just return the json data in file and let webpage to handle the data
* Load unit from webbrowser is decoupled from backend - the data is directly processed in js, no need send to server
