### PR TITLE
Recover skill level selection and put the loading box in front of nav bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.pyc
+*.swp
 tips.txt
-cardsjson - ����.txt
-songsjson - ����.txt
 score.txt
 unit*.txt
 

--- a/static/lldata.js
+++ b/static/lldata.js
@@ -305,23 +305,6 @@ var LLUnit = {
       }, defaultHandleFailedRequest);
    },
 
-   changeskilllevel: function(skilllevel) {
-      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
-      var index = document.getElementById('cardchoice').value
-      if (index == "") {
-         document.getElementById('skillcontainer').style.display = 'none';
-         return;
-      }
-      LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(curCard) {
-         if (curCard && curCard.skill){
-            document.getElementById('skillcontainer').style.display = '';
-            document.getElementById('skilltext').innerHTML = LLUnit.getCardSkillText(curCard, skilllevel);
-         } else {
-            document.getElementById('skillcontainer').style.display = 'none';
-         }
-      }, defaultHandleFailedRequest);
-   },
-
    cardtoskilltype: function(c){
       if (!c)
          return 0
@@ -583,10 +566,12 @@ var LLSkillContainer = (function() {
       if (this.cardData === undefined) {
          if (cardData === undefined) return;
          this.cardData = cardData;
+         this.skillLevel = 0;
          if (!skipRender) this.render();
       } else {
          if (cardData === undefined || this.cardData.id != cardData.id) {
             this.cardData = cardData;
+            this.skillLevel = 0;
             if (!skipRender) this.render();
          }
       }

--- a/static/lldata.js
+++ b/static/lldata.js
@@ -4,6 +4,13 @@
  *   LLData
  *   LLUnit
  *
+ * components:
+ *   LLComponentBase
+ *     +- LLValuedComponent
+ *   LLComponentCollection
+ *     +- LLSkillContainer
+ *
+ * v0.3.0
  * By ben1222
  */
 
@@ -173,6 +180,113 @@ var LLCardData = new LLData('/lldata/cardbrief', '/lldata/card/',
    ['id', 'support', 'rarity', 'jpname', 'name', 'attribute', 'special', 'type', 'skilleffect', 'triggertype', 'jpseries', 'series', 'eponym', 'jpeponym']);
 
 /*
+ * base components:
+ *   LLComponentBase
+ *     +- LLValuedComponent
+ *   LLComponentCollection
+ */
+var LLComponentBase = (function () {
+   var cls = function (id, options) {
+      this.id = id;
+      this.exist = false;
+      this.visible = false;
+      if (this.id) {
+         this.element = document.getElementById(this.id);
+         if (this.element) {
+            this.exist = true;
+            if (this.element.style.display != 'none') {
+               this.visible = true;
+            }
+            if (options && options.listen) {
+               var listenList = Object.keys(options.listen);
+               for (var i = 0; i < listenList.length; i++) {
+                  var e = listenList[i];
+                  this.on(e, options.listen[e]);
+               }
+            }
+         }
+      }
+   };
+   var proto = cls.prototype;
+   proto.show = function () {
+      if (!this.exist) return;
+      if (this.visible) return;
+      this.element.style.display = '';
+      this.visible = true;
+   };
+   proto.hide = function () {
+      if (!this.exist) return;
+      if (!this.visible) return;
+      this.element.style.display = 'none';
+      this.visible = false;
+   };
+   proto.toggleVisible = function () {
+      if (!this.exist) return;
+      if (this.visible) {
+         this.hide();
+      } else {
+         this.show();
+      }
+   };
+   proto.serialize = function () {
+      if (!this.exist) return undefined;
+      return this.visible;
+   };
+   proto.deserialize = function (v) {
+      if (v) {
+         this.show();
+      } else {
+         this.hide();
+      }
+   };
+   proto.on = function (e, callback) {
+      if (!this.exist) return;
+      if ((!e) || (!callback)) return;
+      this.element.addEventListener(e, callback);
+   };
+   return cls;
+})();
+
+var LLValuedComponent = (function() {
+   var cls = function (id, options) {
+      LLComponentBase.call(this, id, options);
+      if (!this.exist) {
+         this.value = undefined;
+         return this;
+      }
+      var vk = (options && options.valueKey ? options.valueKey : (this.element.value ? 'value' : 'innerHTML'));
+      this.valueKey = vk;
+      this.value = this.element[vk];
+   };
+   cls.prototype = new LLComponentBase();
+   cls.prototype.constructor = cls;
+   var proto = cls.prototype;
+   proto.get = function () {
+      return this.value;
+   };
+   proto.set = function (v) {
+      if (!this.exist) return;
+      if (v == this.value) return;
+      this.element[this.valueKey] = v;
+      this.value = v;
+   };
+   //TODO: serialize, deserialize
+   return cls;
+})();
+
+var LLComponentCollection = (function() {
+   var cls = function () {
+      this.components = {};
+   };
+   var proto = cls.prototype;
+   proto.add = function (name, component) {
+      this.components[name] = component;
+   };
+   //TODO: serialize, deserialize
+   return cls;
+})();
+
+/*
  * LLUnit: utility functions for unit related operations, used in llnewunit, llnewunitsis, etc.
  */
 var defaultHandleFailedRequest = function() {
@@ -247,44 +361,6 @@ var LLUnit = {
       }
    },
 
-   changeskilltext: function(card, n) {
-      var postfix = "";
-      if ((n != "") || (String(n) == "0"))
-         postfix = String(n);
-      var skilltype = LLUnit.cardtoskilltype(card);
-      if (skilltype == 0) {
-         document.getElementById("skilltext"+postfix).style.display = "none";
-      } else {
-         document.getElementById("skilltext"+postfix).style.display = "";
-      }
-      //require
-      if ((skilltype == 1) || (skilltype == 6) || (skilltype == 7))
-         document.getElementById("requiretext"+postfix).innerHTML = "个图标"
-      else if ((skilltype == 2) || (skilltype == 9))
-         document.getElementById("requiretext"+postfix).innerHTML = "个perfect"
-      else if (skilltype == 3)
-         document.getElementById("requiretext"+postfix).innerHTML = "分"
-      else if (skilltype == 10)
-         document.getElementById("requiretext"+postfix).innerHTML = "星星perfect"
-      else if ((skilltype == 4) || (skilltype == 5) || (skilltype == 8))
-         document.getElementById("requiretext"+postfix).innerHTML = "秒"
-      else if ((skilltype == 11) || (skilltype == 12) || (skilltype == 13))
-         document.getElementById("requiretext"+postfix).innerHTML = "combo"
-      //effect
-      if ((skilltype == 1) || (skilltype == 2) || (skilltype == 3) || (skilltype == 4) || (skilltype == 10) || (skilltype == 11)){
-         document.getElementById("effecttext"+postfix).innerHTML = "增加"
-         document.getElementById("unittext"+postfix).innerHTML = "分"
-      }
-      if ((skilltype == 5) || (skilltype == 6) || (skilltype == 12)){
-         document.getElementById("effecttext"+postfix).innerHTML = "增强判定"
-         document.getElementById("unittext"+postfix).innerHTML = "秒"
-      }
-      if ((skilltype == 7) || (skilltype == 8) || (skilltype == 9) || (skilltype == 13)){
-         document.getElementById("effecttext"+postfix).innerHTML = "回复"
-         document.getElementById("unittext"+postfix).innerHTML = "点体力"
-      }
-   },
-
    // kizuna from twintailos.js, skilllevel from each page
    applycarddata: function () {
       var index = document.getElementById('cardchoice').value;
@@ -293,14 +369,8 @@ var LLUnit = {
          document.getElementById('cardchoice').style.color = llcard.attcolor[llcard.cards[index].attribute];
          LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(card) {
             document.getElementById("main").value = card.attribute
+            comp_skill.setCardData(card);
 
-            //document.getElementById('skill').value = LLUnit.cardtoskilltype(card)
-            if (card.skill){
-               //skilllevel = parseInt(document.getElementById('skilllevel').innerHTML)
-               //document.getElementById('require').innerHTML = card['skilldetail'][skilllevel].require
-               //document.getElementById('possibility').innerHTML = card['skilldetail'][skilllevel].possibility
-               //document.getElementById('score').innerHTML = card['skilldetail'][skilllevel].time
-            }
             var infolist2 = ["smile", "pure", "cool"]
             if (!mezame){
                for (var i in infolist2){
@@ -315,14 +385,14 @@ var LLUnit = {
                document.getElementById("mezame").value = "已觉醒"
             }
             document.getElementById("kizuna").value = kizuna[card.rarity][mezame]
-            //LLUnit.changeskilltext(card, "")
          }, defaultHandleFailedRequest);
+      } else {
+         comp_skill.setCardData();
       }
-      LLUnit.changeskilllevel(skilllevel);
       LLUnit.changeavatar('imageselect', index, mezame);
    },
 
-   // getimagepath require twintailos.js
+   // getimagepath require twintailosu.js
    changeavatar: function (elementid, cardid, mezame) {
       var path;
       if ((!cardid) || cardid == "0")
@@ -390,7 +460,6 @@ var LLUnit = {
             document.getElementById("maxcost"+String(n)).value = card.minslot;
          }, defaultHandleFailedRequest);
       }
-      //changeskilltext(n)
       if (n == 4){
          LLUnit.changecenter()
       }
@@ -464,5 +533,74 @@ var LLUnit = {
       return true;
    }
 };
+
+/*
+ * componsed components
+ *   LLSkillContainer (require LLUnit)
+ */
+var LLSkillContainer = (function() {
+   var cls = function (options) {
+      LLComponentCollection.call(this);
+      this.skillLevel = 0; // base 0, range 0-7
+      this.cardData = undefined;
+      options = options || {
+         container: 'skillcontainer',
+         lvup: 'skilllvup',
+         lvdown: 'skilllvdown',
+         level: 'skilllevel',
+         text: 'skilltext'
+      };
+      var me = this;
+      this.add('container', new LLComponentBase(options.container));
+      this.add('lvup', new LLComponentBase(options.lvup));
+      this.components.lvup.on('click', function (e) {
+         me.setSkillLevel(me.skillLevel+1);
+      });
+      this.add('lvdown', new LLComponentBase(options.lvdown));
+      this.components.lvdown.on('click', function (e) {
+         me.setSkillLevel(me.skillLevel-1);
+      });
+      this.add('level', new LLValuedComponent(options.level));
+      this.add('text', new LLValuedComponent(options.text));
+      this.setCardData(options.cardData, true);
+      this.render();
+   };
+   cls.prototype = new LLComponentCollection();
+   cls.prototype.constructor = cls;
+   var proto = cls.prototype;
+   proto.setSkillLevel = function (lv) {
+      if (lv == this.skillLevel) return;
+      if (lv > 7) {
+         this.skillLevel = 0;
+      } else if (lv < 0) {
+         this.skillLevel = 7;
+      } else {
+         this.skillLevel = lv;
+      }
+      this.render();
+   };
+   proto.setCardData = function (cardData, skipRender) {
+      if (this.cardData === undefined) {
+         if (cardData === undefined) return;
+         this.cardData = cardData;
+         if (!skipRender) this.render();
+      } else {
+         if (cardData === undefined || this.cardData.id != cardData.id) {
+            this.cardData = cardData;
+            if (!skipRender) this.render();
+         }
+      }
+   };
+   proto.render = function () {
+      if ((!this.cardData) || this.cardData.skill == 0) {
+         this.components.container.hide();
+      } else {
+         this.components.container.show();
+         this.components.text.set(LLUnit.getCardSkillText(this.cardData, this.skillLevel));
+         this.components.level.set(this.skillLevel+1);
+      }
+   };
+   return cls;
+})();
 
 

--- a/static/lldata.js
+++ b/static/lldata.js
@@ -185,9 +185,26 @@ var LLUnit = {
       var level = parseInt(document.getElementById('skilllevel'+String(n)).value)-1;
       if ((level < 0) || (level > 7)) return;
       LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(card) {
-         document.getElementById('require'+String(n)).value = card['skilldetail'][level].require;
-         document.getElementById('possibility'+String(n)).value = card['skilldetail'][level].possibility;
-         document.getElementById('score'+String(n)).value = card['skilldetail'][level].score;
+         //document.getElementById('require'+String(n)).value = card['skilldetail'][level].require;
+         //document.getElementById('possibility'+String(n)).value = card['skilldetail'][level].possibility;
+         //document.getElementById('score'+String(n)).value = card['skilldetail'][level].score;
+      }, defaultHandleFailedRequest);
+   },
+
+   changeskilllevel: function(skilllevel) {
+      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
+      var index = document.getElementById('cardchoice').value
+      if (index == "") {
+         document.getElementById('skillcontainer').style.display = 'none';
+         return;
+      }
+      LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(curCard) {
+         if (curCard && curCard.skill){
+            document.getElementById('skillcontainer').style.display = '';
+            document.getElementById('skilltext').innerHTML = LLUnit.getCardSkillText(curCard, skilllevel);
+         } else {
+            document.getElementById('skillcontainer').style.display = 'none';
+         }
       }, defaultHandleFailedRequest);
    },
 
@@ -268,7 +285,7 @@ var LLUnit = {
       }
    },
 
-   // kizuna from twintailos.js
+   // kizuna from twintailos.js, skilllevel from each page
    applycarddata: function () {
       var index = document.getElementById('cardchoice').value;
       var mezame = (document.getElementById("mezame").checked ? 1 : 0);
@@ -280,9 +297,9 @@ var LLUnit = {
             //document.getElementById('skill').value = LLUnit.cardtoskilltype(card)
             if (card.skill){
                //skilllevel = parseInt(document.getElementById('skilllevel').innerHTML)
-               document.getElementById('require').innerHTML = card['skilldetail'][skilllevel].require
-               document.getElementById('possibility').innerHTML = card['skilldetail'][skilllevel].possibility
-               document.getElementById('score').innerHTML = card['skilldetail'][skilllevel].time
+               //document.getElementById('require').innerHTML = card['skilldetail'][skilllevel].require
+               //document.getElementById('possibility').innerHTML = card['skilldetail'][skilllevel].possibility
+               //document.getElementById('score').innerHTML = card['skilldetail'][skilllevel].time
             }
             var infolist2 = ["smile", "pure", "cool"]
             if (!mezame){
@@ -301,6 +318,7 @@ var LLUnit = {
             //LLUnit.changeskilltext(card, "")
          }, defaultHandleFailedRequest);
       }
+      LLUnit.changeskilllevel(skilllevel);
       LLUnit.changeavatar('imageselect', index, mezame);
    },
 

--- a/templates/components/card-selector.html
+++ b/templates/components/card-selector.html
@@ -113,7 +113,7 @@
    </select>
    <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0">
+卡片：<select id="cardchoice" name="cardchoice">
 		<option value="">载入中...</option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
@@ -135,8 +135,8 @@
 </div>
 <div style="clear:both"></div>
 <p id="skillcontainer" style="display:none">
-   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
-   </input></nobr><br>
+   技能等级 : <input type="button" id="skilllvup" style="height:20px;width:20px;padding:0" value="▲" /> Lv<nospan id="skilllevel">1</nospan> <input type="button" id="skilllvdown" style="height:20px;width:20px;padding:0" value="▼" />
+   <br>
    技能效果 : <span id="skilltext"></span><br/>
    <br/>
 </p>

--- a/templates/components/card-selector.html
+++ b/templates/components/card-selector.html
@@ -128,17 +128,16 @@
 		<option value="cool" style="color:blue">cool</option>
 	</select><br>
 	绊:<input type="number" id="kizuna" name="kizuna" value="0" autocomplete="off" ><br>
-   </div>
-
-   <div style="float:left">
-<img id="imageselect">
-</div>
-<div style="clear:both"></div>
-<p id="skillcontainer" style="display:none">
+<div style="overflow:visible;width:200px">
+<p id="skillcontainer" style="display:none;width:max-content">
    技能等级 : <input type="button" id="skilllvup" style="height:20px;width:20px;padding:0" value="▲" /> Lv<nospan id="skilllevel">1</nospan> <input type="button" id="skilllvdown" style="height:20px;width:20px;padding:0" value="▼" />
    <br>
    技能效果 : <span id="skilltext"></span><br/>
    <br/>
 </p>
-
+</div>
+</div>
+<div style="float:left">
+<img id="imageselect">
+</div>
 

--- a/templates/components/card-selector.html
+++ b/templates/components/card-selector.html
@@ -1,0 +1,144 @@
+<h3>卡片库</h3>
+筛选：<select id="rarity" name="rarity">
+      <option value="">稀有度</option>
+      <option value="N">N</option>
+      <option value="R">R</option>
+      <option value="SR">SR</option>
+      <option value="SSR">SSR</option>
+      <option value="UR">UR</option>
+   </select>
+   <select id="chr" name="chr">
+      <option value="">角色</option>
+      <option value="高坂穗乃果">高坂穗乃果</option>
+      <option value="绚濑绘里">绚濑绘里</option>
+      <option value="南小鸟">南小鸟</option>
+      <option value="园田海未">园田海未</option>
+      <option value="星空凛">星空凛</option>
+      <option value="西木野真姬">西木野真姬</option>
+      <option value="东条希">东条希</option>
+      <option value="小泉花阳">小泉花阳</option>
+      <option value="矢泽妮可">矢泽妮可</option>
+      <option value="高海千歌">高海千歌</option>
+      <option value="樱内梨子">樱内梨子</option>
+      <option value="松浦果南">松浦果南</option>
+      <option value="黑泽黛雅">黑泽黛雅</option>
+      <option value="渡边曜">渡边曜</option>
+      <option value="津岛善子">津岛善子</option>
+      <option value="国木田花丸">国木田花丸</option>
+      <option value="小原鞠莉">小原鞠莉</option>
+      <option value="黑泽露比">黑泽露比</option>
+   </select>
+   <select id="unitgrade" name="unitgrade">
+      <option value="">年级小队</option>
+      <option value="4">μ's</option>
+      <option value="5">Aqours</option>
+      <option value="1">一年级</option>
+      <option value="2">二年级</option>
+      <option value="3">三年级</option>
+      <option value="6">Printemps</option>
+      <option value="7">lilywhite</option>
+      <option value="8">BiBi</option>
+      <option value="9">CYaRon!</option>
+      <option value="10">AZALEA</option>
+      <option value="11">Guilty Kiss</option>
+   </select>
+   <select id="att" name="att">
+      <option value="">属性</option>
+      <option value="smile" style="color:red">smile</option>
+      <option value="pure" style="color:green">pure</option>
+      <option value="cool" style="color:blue">cool</option>
+   </select>
+   <select id="triggertype" name="triggertype">
+      <option value="">触发类型</option>
+      <option value="1">时间</option>
+      <option value="3">图标</option>
+      <option value="4">combo</option>
+      <option value="5">分数</option>
+      <option value="6">perfect</option>
+      <option value="12">星星perfect</option>
+   </select>
+   <select id="skilltype" name="skilltype">
+      <option value="">技能类型</option>
+      <option value="4">小判定</option>
+      <option value="5">大判定</option>
+      <option value="9">回血</option>
+      <option value="11">加分</option>
+   </select>
+   <select id="cardtype" name="cardtype">
+      <option value="">卡片类型</option>
+      <option value="活动卡">活动卡</option>
+      <option value="登录奖励">登录奖励</option>
+   </select>
+   <select id="special" name="special">
+      <option value="">是否特典卡</option>
+      <option value=0>不是特典</option>
+      <option value=1>是特典</option>
+   </select>
+   <select id="setname" name="setname">
+      <option value="">套卡名</option>
+      <option value="初期">初期</option>
+      <option value="職業編">职业篇</option>
+      <option value="動物編">动物篇</option>
+      <option value="8月編">8月篇</option>
+      <option value="9月編">9月篇</option>
+      <option value="10月編">10月篇</option>
+      <option value="11月編">11月篇</option>
+      <option value="12月編">12月篇</option>
+      <option value="1月編">1月篇</option>
+      <option value="2月編">2月篇</option>
+      <option value="3月編">3月篇</option>
+      <option value="4月編">4月篇</option>
+      <option value="5月編">5月篇</option>
+      <option value="6月編">6月篇</option>
+      <option value="7月編">7月篇</option>
+      <option value="チャイナドレス編">旗袍篇</option>
+      <option value="カフェメイド編">女仆篇</option>
+      <option value="ハロウィン編">万圣篇</option>
+      <option value="星座編">星座篇</option>
+      <option value="雪山編">雪山篇</option>
+      <option value="七福神編">七福神篇</option>
+      <option value="バレンタイン編">情人节篇</option>
+      <option value="ホワイトデー編">白色情人节篇</option>
+      <option value="職業編(Part2">职业篇2</option>
+      <option value="サイバー編">电玩篇</option>
+      <option value="手品師編">魔术师篇</option>
+      <option value="マリン編">海兵篇</option>
+      <option value="プール編">泳池篇</option>
+      <option value="くのいち編">忍者篇</option>
+      <option value="動物編(Part2)">动物篇2</option>
+      <option value="舞踏会編">舞踏会篇</option>
+      <option value="クリスマス編">圣诞篇</option>
+      <option value="サーカス編">马戏团篇</option>
+      <option value="妖精の国編">妖精之国篇</option>
+   </select>
+   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
+   <br>
+卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0">
+		<option value="">载入中...</option>
+	</select>
+	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
+	（特典卡需选择觉醒）<br>
+<div style="float:left">
+	裸smile :<input type="number" id="smile" name="smile" value="0" autocomplete="off" style="color:red"></input><br>
+	裸pure :<input type="number" id="pure" name="pure" value="0" autocomplete="off" style="color:green"><br>
+	裸cool :<input type="number" id="cool" name="cool" value="0" autocomplete="off" style="color:blue"><br>
+	主属性 :<select id="main" name="main">
+		<option value="smile" style="color:red">smile</option>
+		<option value="pure" style="color:green">pure</option>
+		<option value="cool" style="color:blue">cool</option>
+	</select><br>
+	绊:<input type="number" id="kizuna" name="kizuna" value="0" autocomplete="off" ><br>
+   </div>
+
+   <div style="float:left">
+<img id="imageselect">
+</div>
+<div style="clear:both"></div>
+<p id="skillcontainer" style="display:none">
+   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
+   </input></nobr><br>
+   技能效果 : <span id="skilltext"></span><br/>
+   <br/>
+</p>
+
+

--- a/templates/components/loadingbox.html
+++ b/templates/components/loadingbox.html
@@ -1,5 +1,5 @@
-<div id="loadingbox" style="position:fixed;top:0px;left:0px;right:0px">
-<div style="display:table;top:0px;background-color:#acf;color:#368;margin-left:auto;margin-right:auto;padding:8px;border-radius:6px;font-size:20px">
+<div id="loadingbox" style="position:fixed;top:0px;left:50%;z-index:1001">
+<div style="background-color:#acf;color:#368;padding:8px;border-radius:6px;font-size:20px;position:relative;left:-50%">
 载入中... <span id="loadingbox_progress"></span>
 </div>
 </div>

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -30,11 +30,11 @@
    var mezame = 0
    var language = 0
 
-   var skilllevel = 0
-
    var defer_onload = $.Deferred();
+   var comp_skill = 0;
    $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
       llcard = new LLCard(cardData);
+      comp_skill = new LLSkillContainer();
       init();
       document.getElementById('cardchoice').options[0].innerHTML = '';
       document.getElementById('loadingbox').style.display = 'none';
@@ -62,20 +62,6 @@
       return result
    }
    
-   function lvlup(){
-      skilllevel += 1
-      if (skilllevel == 8)
-         skilllevel = 0
-      LLUnit.changeskilllevel(skilllevel)
-   }
-
-   function lvldown(){
-      skilllevel -= 1
-      if (skilllevel == -1)
-         skilllevel = 7
-      LLUnit.changeskilllevel(skilllevel)
-   }
-
    function offsetup(){
     if (document.getElementById('offset').value < 50)
 	{
@@ -103,14 +89,18 @@
       var mezame = (document.getElementById("mezame").checked ? 1 : 0);
       if (index != "") {
          document.getElementById('cardchoice').style.color = llcard.attcolor[llcard.cards[index].attribute];
+         LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(curCard) {
+            comp_skill.setCardData(curCard);
+         }, defaultHandleFailedRequest);
    		if (mezame == 0){
    				document.getElementById("mezame").value = "未觉醒"
    		}
    		else{
    				document.getElementById("mezame").value = "已觉醒"
    		}
+      } else {
+         comp_skill.setCardData();
       }
-      LLUnit.changeskilllevel(skilllevel);
       LLUnit.changeavatar('imageselect', index, mezame);
    }
     
@@ -151,6 +141,7 @@
          } else {
             document.getElementById("member"+String(n))[0].selected = true;
          }
+         var skilllevel = comp_skill.skillLevel;
          document.getElementById("skilllevel"+String(n)).innerHTML = String(skilllevel+1);
          document.getElementById('require'+String(n)).value = curCard['skilldetail'][skilllevel].require
          document.getElementById('probability'+String(n)).value = curCard['skilldetail'][skilllevel].possibility
@@ -229,7 +220,6 @@
    
    function init(){
    	//document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
-      skilllevel = 0
    	mezame = getCookie("mezameperfect")
    	language = getCookie("languageperfect")
       if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
@@ -263,7 +253,6 @@
    			nospan[i].innerHTML = getCookie("nospan"+String(i)+"perfect");
    	}
       document.getElementById("mezame").checked = mezame
-      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
 	    if (document.getElementById("member"+String(i)).value != 0){
    		    //changeskilltext(i)
@@ -455,7 +444,7 @@
       <option value="妖精の国編">妖精之国篇</option>
    </select>
    <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0">
+卡片：<select id="cardchoice" name="cardchoice">
 		<option value="">载入中...</option>
 	</select>
 	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
@@ -465,7 +454,7 @@
 </div>
 <div style="clear:both">
 <p id="skillcontainer" style="display:none">
-   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
+   技能等级 : <input type="button" id="skilllvup" style="height:20px;width:20px;padding:0" value="▲" /> Lv<nospan id="skilllevel">1</nospan> <input type="button" id="skilllvdown" style="height:20px;width:20px;padding:0" value="▼" />
    </input></nobr><br>
    技能效果 : <span id="skilltext"></span><br/>
 </p>

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -66,14 +66,14 @@
       skilllevel += 1
       if (skilllevel == 8)
          skilllevel = 0
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    function lvldown(){
       skilllevel -= 1
       if (skilllevel == -1)
          skilllevel = 7
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    function offsetup(){
@@ -98,23 +98,6 @@
 	    document.getElementById('offset').value = 0;
    }
    
-   function changeskilllevel(){
-      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
-      var index = document.getElementById('cardchoice').value
-      if (index == "") {
-         document.getElementById('skillcontainer').style.display = 'none';
-         return;
-      }
-      LoadingUtil.startSingle(LLCardData.getDetailedData(index)).then(function(curCard) {
-         if (curCard && curCard.skill){
-            document.getElementById('skillcontainer').style.display = '';
-            document.getElementById('skilltext').innerHTML = LLUnit.getCardSkillText(curCard, skilllevel);
-         } else {
-            document.getElementById('skillcontainer').style.display = 'none';
-         }
-      }, defaultHandleFailedRequest);
-   }
-
    function changecolor(){
       var index = document.getElementById('cardchoice').value
       var mezame = (document.getElementById("mezame").checked ? 1 : 0);
@@ -127,7 +110,7 @@
    				document.getElementById("mezame").value = "已觉醒"
    		}
       }
-      changeskilllevel();
+      LLUnit.changeskilllevel(skilllevel);
       LLUnit.changeavatar('imageselect', index, mezame);
    }
     
@@ -280,7 +263,7 @@
    			nospan[i].innerHTML = getCookie("nospan"+String(i)+"perfect");
    	}
       document.getElementById("mezame").checked = mezame
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
 	    if (document.getElementById("member"+String(i)).value != 0){
    		    //changeskilltext(i)

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -412,19 +412,6 @@
 	document.getElementById("submembersoperation").style.display="none"
    }
    
-   function sortstrength(){
-   	min = parseInt(document.getElementById("strength0").innerHTML)
-   	minnum = 0
-   	for (i = 1; i < 9; i++){
-   		tmp = parseInt(document.getElementById("strength"+String(i)).innerHTML)
-   		if (tmp < min){
-   			min = tmp
-   			minnum = i
-   		}
-   	}
-   	document.getElementById("strength"+String(minnum)).style.color = "red"
-   }
-   
    
    function saveToCookie(){
    	var inputs = document.getElementsByTagName("input");

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -56,14 +56,16 @@
 
    LLCardData.briefKeys.push('minslot');
    var defer_onload = $.Deferred();
+   var comp_skill = 0;
+
    $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
       llcard = new LLCard(cardData);
+      comp_skill = new LLSkillContainer();
       init();
       document.getElementById('cardchoice').options[0].innerHTML = '';
       document.getElementById('loadingbox').style.display = 'none';
    }, defaultHandleFailedRequest);
 
-   var skilllevel = 0
 	attr = new Array();//↓成员属性值*0
 	HN = new Array();//每张卡的槽数//↓z0
 	grade = new Array();//↓每个成员的年级*
@@ -98,20 +100,6 @@
          result = result[1]
       }
       return result
-   }
-
-   function lvlup(){
-      skilllevel += 1
-      if (skilllevel == 8)
-         skilllevel = 0
-      LLUnit.changeskilllevel(skilllevel)
-   }
-
-   function lvldown(){
-      skilllevel -= 1
-      if (skilllevel == -1)
-         skilllevel = 7
-      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -357,7 +345,6 @@
    }
    function init(){
    	//document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
-      skilllevel = 0
    	mezame = getCookie("mezameunit")
    	language = getCookie("languageunit")
       if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
@@ -387,10 +374,7 @@
    			selects[i].value = getCookie(selects[i].name+"unit");
    	}
       document.getElementById("mezame").checked = mezame
-   	//changeskilltext("")
-      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
-   		//changeskilltext(i)
    		LLUnit.changeavatarn(i)
          calslot(i)
    	}
@@ -426,7 +410,7 @@
 			subunit["pure"]=parseInt(document.getElementById("pure").value)
 			subunit["cool"]=parseInt(document.getElementById("cool").value)
 			subunit[subunit["main"]]+=parseInt(document.getElementById("kizuna").value)
-		subunit["skilllevel"]=1
+		subunit["skilllevel"]=comp_skill.skillLevel+1;
 		subunit["mezame"]=parseInt(mezame)
 		subunit["cardid"]=cardid;
 		subunit["maxcost"]=llcard.cards[cardid].minslot;

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -104,25 +104,14 @@
       skilllevel += 1
       if (skilllevel == 8)
          skilllevel = 0
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    function lvldown(){
       skilllevel -= 1
       if (skilllevel == -1)
          skilllevel = 7
-      changeskilllevel()
-   }
-
-   function changeskilllevel(){
-      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
-      index = document.getElementById('cardchoice').value
-      /*
-      if (cards[index].skill){
-         document.getElementById('require').innerHTML = cards[index]['skilldetail'][skilllevel].require
-         document.getElementById('possibility').innerHTML = cards[index]['skilldetail'][skilllevel].possibility
-         document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
-      }*/
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -399,7 +388,7 @@
    	}
       document.getElementById("mezame").checked = mezame
    	//changeskilltext("")
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
    		//changeskilltext(i)
    		LLUnit.changeavatarn(i)
@@ -1729,143 +1718,9 @@ function calc_bestarm(){
 	时间:<input type="text" id="time" name="time" value="100" autocomplete="off" style="width:50px">秒（从人物出现到最后一个note被击打的时间，不是歌曲长度。部分谱面无长度数据，默认值为110秒）<br>
 	星星perfect数:<input type="text" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
-<h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity">
-      <option value="">稀有度</option>
-      <option value="N">N</option>
-      <option value="R">R</option>
-      <option value="SR">SR</option>
-      <option value="SSR">SSR</option>
-      <option value="UR">UR</option>
-   </select>
-   <select id="chr" name="chr">
-      <option value="">角色</option>
-      <option value="高坂穗乃果">高坂穗乃果</option>
-      <option value="绚濑绘里">绚濑绘里</option>
-      <option value="南小鸟">南小鸟</option>
-      <option value="园田海未">园田海未</option>
-      <option value="星空凛">星空凛</option>
-      <option value="西木野真姬">西木野真姬</option>
-      <option value="东条希">东条希</option>
-      <option value="小泉花阳">小泉花阳</option>
-      <option value="矢泽妮可">矢泽妮可</option>
-      <option value="高海千歌">高海千歌</option>
-      <option value="樱内梨子">樱内梨子</option>
-      <option value="松浦果南">松浦果南</option>
-      <option value="黑泽黛雅">黑泽黛雅</option>
-      <option value="渡边曜">渡边曜</option>
-      <option value="津岛善子">津岛善子</option>
-      <option value="国木田花丸">国木田花丸</option>
-      <option value="小原鞠莉">小原鞠莉</option>
-      <option value="黑泽露比">黑泽露比</option>
-   </select>
-   <select id="unitgrade" name="unitgrade">
-      <option value="">年级小队</option>
-      <option value="4">μ's</option>
-      <option value="5">Aqours</option>
-      <option value="1">一年级</option>
-      <option value="2">二年级</option>
-      <option value="3">三年级</option>
-      <option value="6">Printemps</option>
-      <option value="7">lilywhite</option>
-      <option value="8">BiBi</option>
-      <option value="9">CYaRon!</option>
-      <option value="10">AZALEA</option>
-      <option value="11">Guilty Kiss</option>
-   </select>
-   <select id="att" name="att">
-      <option value="">属性</option>
-      <option value="smile" style="color:red">smile</option>
-      <option value="pure" style="color:green">pure</option>
-      <option value="cool" style="color:blue">cool</option>
-   </select>
-   <select id="triggertype" name="triggertype">
-      <option value="">触发类型</option>
-      <option value="1">时间</option>
-      <option value="3">图标</option>
-      <option value="4">combo</option>
-      <option value="5">分数</option>
-      <option value="6">perfect</option>
-      <option value="12">星星perfect</option>
-   </select>
-   <select id="skilltype" name="skilltype">
-      <option value="">技能类型</option>
-      <option value="4">小判定</option>
-      <option value="5">大判定</option>
-      <option value="9">回血</option>
-      <option value="11">加分</option>
-   </select>
-   <select id="cardtype" name="cardtype">
-      <option value="">卡片类型</option>
-      <option value="活动卡">活动卡</option>
-      <option value="登录奖励">登录奖励</option>
-   </select>
-   <select id="special" name="special">
-      <option value="">是否特典卡</option>
-      <option value=0>不是特典</option>
-      <option value=1>是特典</option>
-   </select>
-   <select id="setname" name="setname">
-      <option value="">套卡名</option>
-      <option value="初期">初期</option>
-      <option value="職業編">职业篇</option>
-      <option value="動物編">动物篇</option>
-      <option value="8月編">8月篇</option>
-      <option value="9月編">9月篇</option>
-      <option value="10月編">10月篇</option>
-      <option value="11月編">11月篇</option>
-      <option value="12月編">12月篇</option>
-      <option value="1月編">1月篇</option>
-      <option value="2月編">2月篇</option>
-      <option value="3月編">3月篇</option>
-      <option value="4月編">4月篇</option>
-      <option value="5月編">5月篇</option>
-      <option value="6月編">6月篇</option>
-      <option value="7月編">7月篇</option>
-      <option value="チャイナドレス編">旗袍篇</option>
-      <option value="カフェメイド編">女仆篇</option>
-      <option value="ハロウィン編">万圣篇</option>
-      <option value="星座編">星座篇</option>
-      <option value="雪山編">雪山篇</option>
-      <option value="七福神編">七福神篇</option>
-      <option value="バレンタイン編">情人节篇</option>
-      <option value="ホワイトデー編">白色情人节篇</option>
-      <option value="職業編(Part2">职业篇2</option>
-      <option value="サイバー編">电玩篇</option>
-      <option value="手品師編">魔术师篇</option>
-      <option value="マリン編">海兵篇</option>
-      <option value="プール編">泳池篇</option>
-      <option value="くのいち編">忍者篇</option>
-      <option value="動物編(Part2)">动物篇2</option>
-      <option value="舞踏会編">舞踏会篇</option>
-      <option value="クリスマス編">圣诞篇</option>
-      <option value="サーカス編">马戏团篇</option>
-      <option value="妖精の国編">妖精之国篇</option>
-   </select>
-   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
-   <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
-		<option value="">载入中...</option>
-	</select>
-	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
-	（特典卡需选择觉醒）<br>
-	
-<div style="float:left">
-	裸smile :<input type="text" id="smile" name="smile" value="0" autocomplete="off" style="color:red"></input><br>
-	裸pure :<input type="text" id="pure" name="pure" value="0" autocomplete="off" style="color:green"><br>
-	裸cool :<input type="text" id="cool" name="cool" value="0" autocomplete="off" style="color:blue"><br>
-	主属性 :<select id="main" name="main">
-		<option value="smile" style="color:red">smile</option>
-		<option value="pure" style="color:green">pure</option>
-		<option value="cool" style="color:blue">cool</option>
-	</select><br>
-	绊:<input type="text" id="kizuna" name="kizuna" value="0" autocomplete="off" ><br>
 
-</div>
+{% include 'components/card-selector.html' %}
 
-   <div style="float:left">
-<img id="imageselect">
-</div>
 <div style="float:left">
 <input type="button" id="addSubselect" value="添加后备" onclick="addselectsub()" ></input>
 <input type="file" name="filesub">
@@ -1873,37 +1728,6 @@ function calc_bestarm(){
 </div>
 <br><br>
 
-<div style="clear:both">
-   <!--
-	技能 :<select id="skill" name="skill">
-		<option value=0>无</option>
-		<option value=1>图标系加分</option>
-		<option value=2>perfect系加分</option>
-		<option value=3>分数系加分</option>
-		<option value=4>时间系加分</option>
-		<option value=5>时间系判定</option>
-		<option value=6>图标系判定</option>
-		<option value=7>图标系回血</option>
-		<option value=8>时间系回血</option>
-		<option value=9>perfect系回血</option>
-		<option value=10>星星perfect系加分</option>
-		<option value=11>combo系加分</option>
-		<option value=12>combo系判定</option>
-		<option value=13>combo系回血</option>
-	</select><br><nobr>-->
-	
-	<p id="skilltext" style="display:none">
-   
-   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
-   </input></nobr><br>
-   技能效果 :每<nobr id="require" name="require"></nobr>
-   <nobr id="requiretext"></nobr>
-   <nobr id="possibility" name="possibility"></nobr>%概率
-   <nobr id="effecttext"></nobr>
-   <nobr id="score" name="score"></nobr>
-   <nobr id="unittext"></nobr>
-   </nobr><br><br>
-	</p>
 <div id="submembersoperation" style="display: none">
 <h4> 备选成员<input type="button" value="保存后备" onclick="savesubmembers()"><input type="button" value="保存全卡" onclick="saveallmembers()"><input type="button" value="队伍填充" onclick="fillunit()"></h4>
 </div>

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -1711,6 +1711,7 @@ function calc_bestarm(){
 <input type="submit" value="读取队伍" onclick="loadsubmembers()">
 </div>
 <br><br>
+<div style="clear:both"></div>
 
 <div id="submembersoperation" style="display: none">
 <h4> 备选成员<input type="button" value="保存后备" onclick="savesubmembers()"><input type="button" value="保存全卡" onclick="saveallmembers()"><input type="button" value="队伍填充" onclick="fillunit()"></h4>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -85,25 +85,14 @@
       skilllevel += 1
       if (skilllevel == 8)
          skilllevel = 0
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    function lvldown(){
       skilllevel -= 1
       if (skilllevel == -1)
          skilllevel = 7
-      changeskilllevel()
-   }
-
-   function changeskilllevel(){
-      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
-      index = document.getElementById('cardchoice').value
-      /*
-      if (cards[index].skill){
-         document.getElementById('require').innerHTML = cards[index]['skilldetail'][skilllevel].require
-         document.getElementById('possibility').innerHTML = cards[index]['skilldetail'][skilllevel].possibility
-         document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
-      }*/
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -278,7 +267,7 @@
       }
       document.getElementById("mezame").checked = mezame
          //changeskilltext("")
-         changeskilllevel()
+         LLUnit.changeskilllevel(skilllevel)
          for (i = 0; i < 9; i++){
             //changeskilltext(i)
             LLUnit.changeavatarn(i)
@@ -975,173 +964,8 @@
 	时间:<input type="number" step="any" id="time" name="time" value="100" autocomplete="off" style="width:50px">秒（从人物出现到最后一个note被击打的时间，不是歌曲长度。部分谱面无长度数据，默认值为110秒）<br>
 	星星perfect数:<input type="number" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
-<h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity">
-      <option value="">稀有度</option>
-      <option value="N">N</option>
-      <option value="R">R</option>
-      <option value="SR">SR</option>
-      <option value="SSR">SSR</option>
-      <option value="UR">UR</option>
-   </select>
-   <select id="chr" name="chr">
-      <option value="">角色</option>
-      <option value="高坂穗乃果">高坂穗乃果</option>
-      <option value="绚濑绘里">绚濑绘里</option>
-      <option value="南小鸟">南小鸟</option>
-      <option value="园田海未">园田海未</option>
-      <option value="星空凛">星空凛</option>
-      <option value="西木野真姬">西木野真姬</option>
-      <option value="东条希">东条希</option>
-      <option value="小泉花阳">小泉花阳</option>
-      <option value="矢泽妮可">矢泽妮可</option>
-      <option value="高海千歌">高海千歌</option>
-      <option value="樱内梨子">樱内梨子</option>
-      <option value="松浦果南">松浦果南</option>
-      <option value="黑泽黛雅">黑泽黛雅</option>
-      <option value="渡边曜">渡边曜</option>
-      <option value="津岛善子">津岛善子</option>
-      <option value="国木田花丸">国木田花丸</option>
-      <option value="小原鞠莉">小原鞠莉</option>
-      <option value="黑泽露比">黑泽露比</option>
-   </select>
-   <select id="unitgrade" name="unitgrade">
-      <option value="">年级小队</option>
-      <option value="4">μ's</option>
-      <option value="5">Aqours</option>
-      <option value="1">一年级</option>
-      <option value="2">二年级</option>
-      <option value="3">三年级</option>
-      <option value="6">Printemps</option>
-      <option value="7">lilywhite</option>
-      <option value="8">BiBi</option>
-      <option value="9">CYaRon!</option>
-      <option value="10">AZALEA</option>
-      <option value="11">Guilty Kiss</option>
-   </select>
-   <select id="att" name="att">
-      <option value="">属性</option>
-      <option value="smile" style="color:red">smile</option>
-      <option value="pure" style="color:green">pure</option>
-      <option value="cool" style="color:blue">cool</option>
-   </select>
-   <select id="triggertype" name="triggertype">
-      <option value="">触发类型</option>
-      <option value="1">时间</option>
-      <option value="3">图标</option>
-      <option value="4">combo</option>
-      <option value="5">分数</option>
-      <option value="6">perfect</option>
-      <option value="12">星星perfect</option>
-   </select>
-   <select id="skilltype" name="skilltype">
-      <option value="">技能类型</option>
-      <option value="4">小判定</option>
-      <option value="5">大判定</option>
-      <option value="9">回血</option>
-      <option value="11">加分</option>
-   </select>
-   <select id="cardtype" name="cardtype">
-      <option value="">卡片类型</option>
-      <option value="活动卡">活动卡</option>
-      <option value="登录奖励">登录奖励</option>
-   </select>
-   <select id="special" name="special">
-      <option value="">是否特典卡</option>
-      <option value=0>不是特典</option>
-      <option value=1>是特典</option>
-   </select>
-   <select id="setname" name="setname">
-      <option value="">套卡名</option>
-      <option value="初期">初期</option>
-      <option value="職業編">职业篇</option>
-      <option value="動物編">动物篇</option>
-      <option value="8月編">8月篇</option>
-      <option value="9月編">9月篇</option>
-      <option value="10月編">10月篇</option>
-      <option value="11月編">11月篇</option>
-      <option value="12月編">12月篇</option>
-      <option value="1月編">1月篇</option>
-      <option value="2月編">2月篇</option>
-      <option value="3月編">3月篇</option>
-      <option value="4月編">4月篇</option>
-      <option value="5月編">5月篇</option>
-      <option value="6月編">6月篇</option>
-      <option value="7月編">7月篇</option>
-      <option value="チャイナドレス編">旗袍篇</option>
-      <option value="カフェメイド編">女仆篇</option>
-      <option value="ハロウィン編">万圣篇</option>
-      <option value="星座編">星座篇</option>
-      <option value="雪山編">雪山篇</option>
-      <option value="七福神編">七福神篇</option>
-      <option value="バレンタイン編">情人节篇</option>
-      <option value="ホワイトデー編">白色情人节篇</option>
-      <option value="職業編(Part2">职业篇2</option>
-      <option value="サイバー編">电玩篇</option>
-      <option value="手品師編">魔术师篇</option>
-      <option value="マリン編">海兵篇</option>
-      <option value="プール編">泳池篇</option>
-      <option value="くのいち編">忍者篇</option>
-      <option value="動物編(Part2)">动物篇2</option>
-      <option value="舞踏会編">舞踏会篇</option>
-      <option value="クリスマス編">圣诞篇</option>
-      <option value="サーカス編">马戏团篇</option>
-      <option value="妖精の国編">妖精之国篇</option>
-   </select>
-   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
-   <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
-		<option value="">载入中...</option>
-	</select>
-	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
-	（特典卡需选择觉醒）<br>
-<div style="float:left">
-	裸smile :<input type="number" id="smile" name="smile" value="0" autocomplete="off" style="color:red"></input><br>
-	裸pure :<input type="number" id="pure" name="pure" value="0" autocomplete="off" style="color:green"><br>
-	裸cool :<input type="number" id="cool" name="cool" value="0" autocomplete="off" style="color:blue"><br>
-	主属性 :<select id="main" name="main">
-		<option value="smile" style="color:red">smile</option>
-		<option value="pure" style="color:green">pure</option>
-		<option value="cool" style="color:blue">cool</option>
-	</select><br>
-	绊:<input type="number" id="kizuna" name="kizuna" value="0" autocomplete="off" ><br>
-   </div>
 
-   <div style="float:left">
-<img id="imageselect">
-</div>
-<div style="clear:both">
-   <!--
-	技能 :<select id="skill" name="skill">
-		<option value=0>无</option>
-		<option value=1>图标系加分</option>
-		<option value=2>perfect系加分</option>
-		<option value=3>分数系加分</option>
-		<option value=4>时间系加分</option>
-		<option value=5>时间系判定</option>
-		<option value=6>图标系判定</option>
-		<option value=7>图标系回血</option>
-		<option value=8>时间系回血</option>
-		<option value=9>perfect系回血</option>
-		<option value=10>星星perfect系加分</option>
-		<option value=11>combo系加分</option>
-		<option value=12>combo系判定</option>
-		<option value=13>combo系回血</option>
-	</select><br><nobr>-->
-
-	<p id="skilltext" style="display:none">
-
-   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
-   </input></nobr><br>
-   技能效果 :每<nobr id="require" name="require"></nobr>
-   <nobr id="requiretext"></nobr>
-   <nobr id="possibility" name="possibility"></nobr>%概率
-   <nobr id="effecttext"></nobr>
-   <nobr id="score" name="score"></nobr>
-   <nobr id="unittext"></nobr>
-   </nobr><br><br>
-	</p>
-<br><br>
+{% include 'components/card-selector.html' %}
 
 <h3>队伍属性</h3>
 <div>
@@ -1339,7 +1163,6 @@
   </div>
 </div>
 
-</div>
 </div>
 <div style="clear:both">
 </div>

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -277,7 +277,6 @@
          if (curCookie != "") selects[i].value = curCookie;
       }
       document.getElementById("mezame").checked = mezame
-      try {
          //changeskilltext("")
          changeskilllevel()
          for (i = 0; i < 9; i++){
@@ -290,26 +289,9 @@
          // above codes may select songs/cards/filters according to cookies, so refresh it...
          llsong.onSongFilterChange();
          llcard.onCardFilterChange();
-      } catch (err) {
-        console.log(err);
-      }
 
       {{additional_script|safe}}
    }
-
-   function sortstrength(){
-   	min = parseInt(document.getElementById("strength0").innerHTML)
-   	minnum = 0
-   	for (i = 1; i < 9; i++){
-   		tmp = parseInt(document.getElementById("strength"+String(i)).innerHTML)
-   		if (tmp < min){
-   			min = tmp
-   			minnum = i
-   		}
-   	}
-   	document.getElementById("strength"+String(minnum)).style.color = "red"
-   }
-
 
    function saveToCookie(){
    	var inputs = document.getElementsByTagName("input");

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -57,11 +57,11 @@
                   ["桜内梨子","津島善子","小原鞠莉"]]
 
 
-   var skilllevel = 0
-
    var defer_onload = $.Deferred();
+   var comp_skill = 0;
    $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
       llcard = new LLCard(cardData);
+      comp_skill = new LLSkillContainer();
       init();
       document.getElementById('cardchoice').options[0].innerHTML = '';
       document.getElementById('loadingbox').style.display = 'none';
@@ -79,20 +79,6 @@
          result = result[1]
       }
       return result
-   }
-
-   function lvlup(){
-      skilllevel += 1
-      if (skilllevel == 8)
-         skilllevel = 0
-      LLUnit.changeskilllevel(skilllevel)
-   }
-
-   function lvldown(){
-      skilllevel -= 1
-      if (skilllevel == -1)
-         skilllevel = 7
-      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -235,7 +221,6 @@
 
    function init(){
       //document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
-      skilllevel = 0
       mezame = getCookie("mezameunit")
       language = getCookie("languageunit")
       if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
@@ -266,10 +251,7 @@
          if (curCookie != "") selects[i].value = curCookie;
       }
       document.getElementById("mezame").checked = mezame
-         //changeskilltext("")
-         LLUnit.changeskilllevel(skilllevel)
          for (i = 0; i < 9; i++){
-            //changeskilltext(i)
             LLUnit.changeavatarn(i)
             calslot(i)
          }

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -949,6 +949,7 @@
 
 {% include 'components/card-selector.html' %}
 
+<div style="clear:both"></div>
 <h3>队伍属性</h3>
 <div>
 <div style="float:left">

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -1271,6 +1271,7 @@ function calc_bestarm(){
 
 {% include 'components/card-selector.html' %}
 
+<div style="clear:both"></div>
 <h3>队伍属性</h3>
 <div>
 <div style="float:left">

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -94,25 +94,14 @@
       skilllevel += 1
       if (skilllevel == 8)
          skilllevel = 0
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    function lvldown(){
       skilllevel -= 1
       if (skilllevel == -1)
          skilllevel = 7
-      changeskilllevel()
-   }
-
-   function changeskilllevel(){
-      document.getElementById('skilllevel').innerHTML = String(skilllevel+1)
-      index = document.getElementById('cardchoice').value
-      /*
-      if (cards[index].skill){
-         document.getElementById('require').innerHTML = cards[index]['skilldetail'][skilllevel].require
-         document.getElementById('possibility').innerHTML = cards[index]['skilldetail'][skilllevel].possibility
-         document.getElementById('score').innerHTML = cards[index]['skilldetail'][skilllevel].score
-      }*/
+      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -287,7 +276,7 @@
    	}
       document.getElementById("mezame").checked = mezame
    	//changeskilltext("")
-      changeskilllevel()
+      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
    		//changeskilltext(i)
    		LLUnit.changeavatarn(i)
@@ -1296,173 +1285,8 @@ function calc_bestarm(){
 	时间:<input type="text" id="time" name="time" value="100" autocomplete="off" style="width:50px">秒（从人物出现到最后一个note被击打的时间，不是歌曲长度。部分谱面无长度数据，默认值为110秒）<br>
 	星星perfect数:<input type="text" id="starperfect" name="starperfect" value="47" autocomplete="off" style="width:50px">（只有星星系加分需要填写）<br>
 <br>
-<h3>卡片库</h3>
-筛选：<select id="rarity" name="rarity">
-      <option value="">稀有度</option>
-      <option value="N">N</option>
-      <option value="R">R</option>
-      <option value="SR">SR</option>
-      <option value="SSR">SSR</option>
-      <option value="UR">UR</option>
-   </select>
-   <select id="chr" name="chr">
-      <option value="">角色</option>
-      <option value="高坂穗乃果">高坂穗乃果</option>
-      <option value="绚濑绘里">绚濑绘里</option>
-      <option value="南小鸟">南小鸟</option>
-      <option value="园田海未">园田海未</option>
-      <option value="星空凛">星空凛</option>
-      <option value="西木野真姬">西木野真姬</option>
-      <option value="东条希">东条希</option>
-      <option value="小泉花阳">小泉花阳</option>
-      <option value="矢泽妮可">矢泽妮可</option>
-      <option value="高海千歌">高海千歌</option>
-      <option value="樱内梨子">樱内梨子</option>
-      <option value="松浦果南">松浦果南</option>
-      <option value="黑泽黛雅">黑泽黛雅</option>
-      <option value="渡边曜">渡边曜</option>
-      <option value="津岛善子">津岛善子</option>
-      <option value="国木田花丸">国木田花丸</option>
-      <option value="小原鞠莉">小原鞠莉</option>
-      <option value="黑泽露比">黑泽露比</option>
-   </select>
-   <select id="unitgrade" name="unitgrade">
-      <option value="">年级小队</option>
-      <option value="4">μ's</option>
-      <option value="5">Aqours</option>
-      <option value="1">一年级</option>
-      <option value="2">二年级</option>
-      <option value="3">三年级</option>
-      <option value="6">Printemps</option>
-      <option value="7">lilywhite</option>
-      <option value="8">BiBi</option>
-      <option value="9">CYaRon!</option>
-      <option value="10">AZALEA</option>
-      <option value="11">Guilty Kiss</option>
-   </select>
-   <select id="att" name="att">
-      <option value="">属性</option>
-      <option value="smile" style="color:red">smile</option>
-      <option value="pure" style="color:green">pure</option>
-      <option value="cool" style="color:blue">cool</option>
-   </select>
-   <select id="triggertype" name="triggertype">
-      <option value="">触发类型</option>
-      <option value="1">时间</option>
-      <option value="3">图标</option>
-      <option value="4">combo</option>
-      <option value="5">分数</option>
-      <option value="6">perfect</option>
-      <option value="12">星星perfect</option>
-   </select>
-   <select id="skilltype" name="skilltype">
-      <option value="">技能类型</option>
-      <option value="4">小判定</option>
-      <option value="5">大判定</option>
-      <option value="9">回血</option>
-      <option value="11">加分</option>
-   </select>
-   <select id="cardtype" name="cardtype">
-      <option value="">卡片类型</option>
-      <option value="活动卡">活动卡</option>
-      <option value="登录奖励">登录奖励</option>
-   </select>
-   <select id="special" name="special">
-      <option value="">是否特典卡</option>
-      <option value=0>不是特典</option>
-      <option value=1>是特典</option>
-   </select>
-   <select id="setname" name="setname">
-      <option value="">套卡名</option>
-      <option value="初期">初期</option>
-      <option value="職業編">职业篇</option>
-      <option value="動物編">动物篇</option>
-      <option value="8月編">8月篇</option>
-      <option value="9月編">9月篇</option>
-      <option value="10月編">10月篇</option>
-      <option value="11月編">11月篇</option>
-      <option value="12月編">12月篇</option>
-      <option value="1月編">1月篇</option>
-      <option value="2月編">2月篇</option>
-      <option value="3月編">3月篇</option>
-      <option value="4月編">4月篇</option>
-      <option value="5月編">5月篇</option>
-      <option value="6月編">6月篇</option>
-      <option value="7月編">7月篇</option>
-      <option value="チャイナドレス編">旗袍篇</option>
-      <option value="カフェメイド編">女仆篇</option>
-      <option value="ハロウィン編">万圣篇</option>
-      <option value="星座編">星座篇</option>
-      <option value="雪山編">雪山篇</option>
-      <option value="七福神編">七福神篇</option>
-      <option value="バレンタイン編">情人节篇</option>
-      <option value="ホワイトデー編">白色情人节篇</option>
-      <option value="職業編(Part2">职业篇2</option>
-      <option value="サイバー編">电玩篇</option>
-      <option value="手品師編">魔术师篇</option>
-      <option value="マリン編">海兵篇</option>
-      <option value="プール編">泳池篇</option>
-      <option value="くのいち編">忍者篇</option>
-      <option value="動物編(Part2)">动物篇2</option>
-      <option value="舞踏会編">舞踏会篇</option>
-      <option value="クリスマス編">圣诞篇</option>
-      <option value="サーカス編">马戏团篇</option>
-      <option value="妖精の国編">妖精之国篇</option>
-   </select>
-   <input type="checkbox" id="showncard" name="showncard">显示N卡</input>
-   <br>
-卡片：<select id="cardchoice" name="cardchoice" onchange="skilllevel = 0;changeskilllevel()">
-		<option value="">载入中...</option>
-	</select>
-	<input type="checkbox" id="mezame" name="mezame" onclick="toMezame()">觉醒</input><input type="button" id="language" name="language" onclick="changeLanguage()" value="切换语言"></input>
-	（特典卡需选择觉醒）<br>
-<div style="float:left">
-	裸smile :<input type="text" id="smile" name="smile" value="0" autocomplete="off" style="color:red"></input><br>
-	裸pure :<input type="text" id="pure" name="pure" value="0" autocomplete="off" style="color:green"><br>
-	裸cool :<input type="text" id="cool" name="cool" value="0" autocomplete="off" style="color:blue"><br>
-	主属性 :<select id="main" name="main">
-		<option value="smile" style="color:red">smile</option>
-		<option value="pure" style="color:green">pure</option>
-		<option value="cool" style="color:blue">cool</option>
-	</select><br>
-	绊:<input type="text" id="kizuna" name="kizuna" value="0" autocomplete="off" ><br>
-   </div>
 
-   <div style="float:left">
-<img id="imageselect">
-</div>
-<div style="clear:both">
-   <!--
-	技能 :<select id="skill" name="skill">
-		<option value=0>无</option>
-		<option value=1>图标系加分</option>
-		<option value=2>perfect系加分</option>
-		<option value=3>分数系加分</option>
-		<option value=4>时间系加分</option>
-		<option value=5>时间系判定</option>
-		<option value=6>图标系判定</option>
-		<option value=7>图标系回血</option>
-		<option value=8>时间系回血</option>
-		<option value=9>perfect系回血</option>
-		<option value=10>星星perfect系加分</option>
-		<option value=11>combo系加分</option>
-		<option value=12>combo系判定</option>
-		<option value=13>combo系回血</option>
-	</select><br><nobr>-->
-	
-	<p id="skilltext" style="display:none">
-   
-   技能等级 : <input type="button" style="height:20px;width:20px;padding:0" value="▲" onclick="lvlup()"></input> Lv<nospan id="skilllevel">1</nospan> <input type="button" style="height:20px;width:20px;padding:0" value="▼" onclick="lvldown()"></input></nobr>
-   </input></nobr><br>
-   技能效果 :每<nobr id="require" name="require"></nobr>
-   <nobr id="requiretext"></nobr>
-   <nobr id="possibility" name="possibility"></nobr>%概率
-   <nobr id="effecttext"></nobr>
-   <nobr id="score" name="score"></nobr>
-   <nobr id="unittext"></nobr>
-   </nobr><br><br>
-	</p>
-<br><br>
+{% include 'components/card-selector.html' %}
 
 <h3>队伍属性</h3>
 <div>

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -46,7 +46,6 @@
                   ["桜内梨子","津島善子","小原鞠莉"]]
 
    
-   var skilllevel = 0
 	attr = new Array();//↓成员属性值*0
 	HN = new Array();//每张卡的槽数//↓z0
 	grade = new Array();//↓每个成员的年级*
@@ -69,8 +68,10 @@
    currslot=0;
 
    var defer_onload = $.Deferred();
+   var comp_skill = 0;
    $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
       llcard = new LLCard(cardData);
+      comp_skill = new LLSkillContainer();
       init();
       document.getElementById('cardchoice').options[0].innerHTML = '';
       document.getElementById('loadingbox').style.display = 'none';
@@ -88,20 +89,6 @@
          result = result[1]
       }
       return result
-   }
-
-   function lvlup(){
-      skilllevel += 1
-      if (skilllevel == 8)
-         skilllevel = 0
-      LLUnit.changeskilllevel(skilllevel)
-   }
-
-   function lvldown(){
-      skilllevel -= 1
-      if (skilllevel == -1)
-         skilllevel = 7
-      LLUnit.changeskilllevel(skilllevel)
    }
 
    naipan = 480
@@ -246,7 +233,6 @@
    
    function init(){
       //document.getElementById('avatar0').src = 'http://i2.tietuku.com/8baa9a87cc083022.jpg'
-      skilllevel = 0
       mezame = getCookie("mezameunit")
       language = getCookie("languageunit")
       if (mezame == "") mezame = 0; else mezame = parseInt(mezame);
@@ -275,10 +261,7 @@
    			selects[i].value = getCookie(selects[i].name+"unit");
    	}
       document.getElementById("mezame").checked = mezame
-   	//changeskilltext("")
-      LLUnit.changeskilllevel(skilllevel)
    	for (i = 0; i < 9; i++){
-   		//changeskilltext(i)
    		LLUnit.changeavatarn(i)
          calslot(i)
    	}

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -286,7 +286,6 @@
    			selects[i].value = getCookie(selects[i].name+"unit");
    	}
       document.getElementById("mezame").checked = mezame
-      //try {
    	//changeskilltext("")
       changeskilllevel()
    	for (i = 0; i < 9; i++){
@@ -299,24 +298,9 @@
          // above codes may select songs/cards/filters according to cookies, so refresh it...
          llsong.onSongFilterChange();
          llcard.onCardFilterChange();
-      //} catch (err) {}
 
       {{additional_script|safe}}
    }
-   
-   function sortstrength(){
-   	min = parseInt(document.getElementById("strength0").innerHTML)
-   	minnum = 0
-   	for (i = 1; i < 9; i++){
-   		tmp = parseInt(document.getElementById("strength"+String(i)).innerHTML)
-   		if (tmp < min){
-   			min = tmp
-   			minnum = i
-   		}
-   	}
-   	document.getElementById("strength"+String(minnum)).style.color = "red"
-   }
-   
    
    function saveToCookie(){
    	var inputs = document.getElementsByTagName("input");


### PR DESCRIPTION
New features:
* The skill level selection is recovered on `llnewunit`, `llnewunitsis`, `llnewautounit`, `llcoverage`
![pr11-](https://user-images.githubusercontent.com/17180510/37531361-e3b20d1e-2976-11e8-8705-7f35828d230f.png)

Fixes:
* Fix the issue that loading box can be covered by the navigation bar
![pr11-](https://user-images.githubusercontent.com/17180510/37531384-fb206310-2976-11e8-9e8d-c5eb9c6c6ff9.png)

Developer enhancements:
* Move card selects to a component html that reused in `llnewunit`, `llnewunitsis`, `llnewautounit`
* Add `LLSkillContainer` to unify skill level selection functionality and used in `llnewunit`, `llnewunitsis`, `llnewautounit`, `llcoverage`