### PR TITLE
show swing note data in llsongdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ newsongsjson.txt
 .DS_Store
 
 *.db_
+live

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -7,7 +7,7 @@
     <link href="//cdn.bootcss.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
     <!--link href="//cdn.bootcss.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" rel="stylesheet"-->
     <script src="//cdn.bootcss.com/jquery/3.2.1/jquery.min.js"></script>
-    <script src="/static/masonry.pkgd.min.js"></script>
+    {% if useMasonry %}<script src="/static/masonry.pkgd.min.js"></script>{% endif %}
     <script src="//cdn.bootcss.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <link rel="stylesheet" media="all" href="/static/han.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='llhelper.css') }}">
@@ -95,8 +95,10 @@
   {% endblock %}
   {% endif %}
   <script src="//cdnjs.cloudflare.com/ajax/libs/Han/3.2.7/han.min.js"></script>
+  {% if useMasonry %}
   <script>
     $('.row').masonry()
   </script>
+  {% endif %}
   {% include "footer.html" %}
 </html>

--- a/templates/llactivity.html
+++ b/templates/llactivity.html
@@ -3,6 +3,7 @@
 {% set category="活动算心" %}
 {% set category_link="/#event-expense" %}
 {% set title="活动助手" %}
+{% set useMasonry=True %}
 
 {% set need_item = True %}
 

--- a/templates/llchallengefestival.html
+++ b/templates/llchallengefestival.html
@@ -4,6 +4,7 @@
 {% set category_link="/#event-expense" %}
 {% set title="Challenge Festival 助手" %}
 {% set event_abbr="打歌" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
    <script src="http://lovelive.oss-cn-beijing.aliyuncs.com/Js/ReadPredCN.js"></script>

--- a/templates/lllvlup.html
+++ b/templates/lllvlup.html
@@ -3,6 +3,7 @@
 {% set category="其他应用" %}
 {% set category_link="/#other-tools" %}
 {% set title="升级时间计算" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>

--- a/templates/llmedleyfestival.html
+++ b/templates/llmedleyfestival.html
@@ -4,6 +4,7 @@
 {% set category_link="/#event-expense" %}
 {% set title="Medley Festival 助手" %}
 {% set event_abbr="MF" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
    <script src="http://lovelive.oss-cn-beijing.aliyuncs.com/Js/ReadPredCN.js"></script>

--- a/templates/llnakayoshi.html
+++ b/templates/llnakayoshi.html
@@ -4,6 +4,7 @@
 {% set category_link="/#event-expense" %}
 {% set title="协力助手" %}
 {% set event_abbr="协力" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
    <script src="http://lovelive.oss-cn-beijing.aliyuncs.com/Js/ReadPredCN.js"></script>

--- a/templates/llrally.html
+++ b/templates/llrally.html
@@ -4,6 +4,7 @@
 {% set category_link="/#event-expense" %}
 {% set title="散步拉力赛助手" %}
 {% set event_abbr="散拉" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
    <script src="http://lovelive.oss-cn-beijing.aliyuncs.com/Js/ReadPredCN.js"></script>

--- a/templates/llscorematch.html
+++ b/templates/llscorematch.html
@@ -4,6 +4,7 @@
 {% set category_link="/#event-expense" %}
 {% set title="Score Match 助手" %}
 {% set event_abbr="SM" %}
+{% set useMasonry=True %}
 
 {% block additional_header %}
 	<script src="http://lovelive.oss-cn-beijing.aliyuncs.com/Js/ReadPredCN.js"></script>

--- a/templates/llsongdata.html
+++ b/templates/llsongdata.html
@@ -72,7 +72,8 @@
          'attrcolor': ['songchoice', 'attribute', 'name', 'jpname']
       };
       var infolist = ['attribute', 'totaltime', 'bpm', 'name', 'jpname',
-        'combo', 'time', 'stardifficulty', 'randomdifficulty', 'star', 'cscore', 'bscore', 'ascore', 'sscore', 'lp', 'exp'];
+        'combo', 'time', 'stardifficulty', 'randomdifficulty', 'star', 'cscore', 'bscore', 'ascore', 'sscore', 'lp', 'exp',
+        'slider', 'swing', 'swingslider'];
       for (var i in infolist) {
          applyTarget[infolist[i]] = [[infolist[i], 'innerHTML']];
       }
@@ -95,8 +96,12 @@
       var weights = curSongWithDiff.positionweight;
       var c = parseInt(curSongWithDiff.combo);
       for (var i = 0; i < 9; i++) {
-         totalweight += parseFloat(weights[i]);
+         document.getElementById('positionnote' + i).innerHTML = curSongWithDiff.positionnote[i];
+         document.getElementById('positionslider' + i).innerHTML = curSongWithDiff.positionslider[i];
+         document.getElementById('positionswing' + i).innerHTML = curSongWithDiff.positionswing[i];
+         document.getElementById('positionswingslider' + i).innerHTML = curSongWithDiff.positionswingslider[i];
          document.getElementById('positionweight' + i).innerHTML = weights[i];
+         totalweight += parseFloat(weights[i]);
       }
       var sl = (totalweight-c)*100/0.25/c;
       document.getElementById('noteweight').innerHTML = totalweight;
@@ -303,6 +308,12 @@
 	<dd id='bpm'> </dd>
 	<dt>星星数</dt>
 	<dd id='star'> </dd>
+	<dt>长条按键数</dt>
+	<dd id='slider'> </dd>
+	<dt>滑键数</dt>
+	<dd id='swing'> </dd>
+	<dt>滑键长条数</dt>
+	<dd id='swingslider'> </dd>
 </dl>
 
 
@@ -386,6 +397,30 @@
 </tr>
 </thead>
 <tbody>
+<tr>
+	<th>普通按键</th>
+	{% for i in range(0, 9)%}
+		<td id="positionnote{{i}}"></td>
+	{% endfor %}
+</tr>
+<tr>
+	<th>长条按键</th>
+	{% for i in range(0, 9)%}
+		<td id="positionslider{{i}}"></td>
+	{% endfor %}
+</tr>
+<tr>
+	<th>滑键</th>
+	{% for i in range(0, 9)%}
+		<td id="positionswing{{i}}"></td>
+	{% endfor %}
+</tr>
+<tr>
+	<th>滑键长条</th>
+	{% for i in range(0, 9)%}
+		<td id="positionswingslider{{i}}"></td>
+	{% endfor %}
+</tr>
 <tr>
 	<th>权重</th>
 	{% for i in range(0, 9)%}


### PR DESCRIPTION
New feature:
* Show note count of each type in `llsongdata` page:
![pr54-](https://user-images.githubusercontent.com/17180510/49520537-72f6b880-f8de-11e8-911e-dae9dae889ca.png)

Bug fixes:
* Only enable `Masonry` on pages that needs it (the loveca calculate pages), so that layout of other pages won't be affacted unexpectedly when they use `row` class

Developer enhancements:
* `updateweight2.py` will cache live map json in local folder `live/json/`
* `updateweight2.py` could update note type data to meet the requirement of new `llsongdata` page
