### PR TITLE
add score distribution chart

### DIFF
--- a/static/lldata.js
+++ b/static/lldata.js
@@ -3628,9 +3628,98 @@ var LLDataVersionSelectorComponent = (function () {
          'lldata': lldata,
          'versionChanged': versionChangedHandler
       };
-      //element.appendChild(createElement('span', {'innerHTML': '选择数据版本:'}));
       element.appendChild(createVersionSelector(controller));
    }
    var cls = LLDataVersionSelectorComponent_cls;
    return cls;
 })();
+
+var LLScoreDistributionChart = (function () {
+   function makeCommonOptions() {
+      return {
+         title: {
+            text: '得分分布曲线'
+         },
+         credits: {
+            text: 'LLhelper',
+            href: 'http://llhelper.com'
+         },
+         xAxis: {
+            min: 0,
+            max: 100,
+            tickInterval: 10,
+            crosshair: true,
+            labels: {
+               format: '{value}%'
+            }
+         },
+         yAxis: {
+            title: {
+               text: '得分'
+            }
+         },
+         tooltip: {
+            headerFormat: '<span style="font-size: 10px">{point.key}%</span><br/>',
+            shared: true
+         },
+         plotOptions: {
+            line: {
+               marker: {
+                  radius: 2,
+                  symbol: 'circle'
+               },
+               pointStart: 1
+            }
+         }
+      };
+   };
+   function makeSeries(series, name) {
+      var ret = {
+         'type': 'line',
+         //'showCheckbox': true,
+         'name': name
+      }
+      if (series.length == 99) {
+         ret['data'] = series;
+      } else if (series.length == 101) {
+         ret['data'] = series.slice(1, 100).reverse();
+      } else {
+         console.error('Unknown series');
+         concole.log(series);
+         ret['data'] = series;
+      }
+      return ret;
+   };
+   // LLScoreDistributionChart
+   // {
+   //    chart: Highcharts chart
+   //    addSeries: function(data)
+   //    show: function()
+   //    hide: function()
+   // }
+   function LLScoreDistributionChart_cls(id, series) {
+      var element = LLUnit.getElement(id);
+      if (!Highcharts) {
+         console.error('Not included Highcharts');
+      }
+      var baseComponent = new LLComponentBase(element);
+      baseComponent.show(); // need show before create chart, otherwise the canvas size is wrong...
+      var options = makeCommonOptions();
+      var seriesOptions = [];
+      var nameId = 1;
+      for (; nameId <= series.length; nameId++) {
+         seriesOptions.push(makeSeries(series[nameId-1], String(nameId)));
+      }
+      options['series'] = seriesOptions;
+      this.chart = Highcharts.chart(element, options);
+      this.addSeries = function(data) {
+         this.chart.addSeries(makeSeries(data, String(nameId)));
+         nameId++;
+      };
+      this.show = function() { baseComponent.show(); }
+      this.hide = function() { baseComponent.hide(); }
+   }
+   var cls = LLScoreDistributionChart_cls;
+   return cls;
+})();
+

--- a/templates/llnewautounit.html
+++ b/templates/llnewautounit.html
@@ -8,6 +8,7 @@
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='lldata.js') }}"></script>
+   <script type="text/javascript" src="/static/js/highcharts/highcharts.js"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -35,6 +36,7 @@
    var comp_swapper = 0;
    var unit_member_controller = [];
    var comp_resultmic = 0;
+   var comp_distribution_chart = 0;
 
    function getUnitMember(pos) {
       var props = ['cardid','mezame','main','smile','pure','cool','skilllevel','gemnum','gemsinglepercent','gemallpercent','gemskill','gemacc','gemmember','gemnonet','maxcost'];
@@ -592,6 +594,11 @@
          document.getElementById('simresult0').innerHTML = llteam.maxScore;
          document.getElementById('simresult100').innerHTML = llteam.minScore;
          document.getElementById('distributionresult').style.display = '';
+         if (!comp_distribution_chart) {
+            comp_distribution_chart = new LLScoreDistributionChart('score_chart', [llteam.naivePercentile]);
+         } else {
+            comp_distribution_chart.addSeries(llteam.naivePercentile);
+         }
       } else {
          document.getElementById('averagescore').innerHTML = llteam.averageScore;
          document.getElementById('distributionresult').style.display = 'none';
@@ -1114,6 +1121,7 @@
 </tr>
 </table>
 </div>
+<div id='score_chart' style='width:100%;height:400px;display:none'></div>
 {% endblock %}
 
 {% block back_notice %}

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -8,6 +8,7 @@
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='lldata.js') }}"></script>
+   <script type="text/javascript" src="/static/js/highcharts/highcharts.js"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
       img {height:65px;width:65px}
@@ -34,6 +35,7 @@
    var comp_skill = 0;
    var comp_cardselector = 0;
    var comp_resultmic = 0;
+   var comp_distribution_chart = 0;
 
    $.when(LLCardData.getAllBriefData(), LLSongData.getAllBriefData(), defer_onload).then(function (cardData, songData) {
       // init components
@@ -357,6 +359,11 @@
          document.getElementById('simresult0').innerHTML = llteam.maxScore;
          document.getElementById('simresult100').innerHTML = llteam.minScore;
          document.getElementById('distributionresult').style.display = '';
+         if (!comp_distribution_chart) {
+            comp_distribution_chart = new LLScoreDistributionChart('score_chart', [llteam.naivePercentile]);
+         } else {
+            comp_distribution_chart.addSeries(llteam.naivePercentile);
+         }
       } else {
          document.getElementById('averagescore').innerHTML = llteam.averageScore;
          document.getElementById('distributionresult').style.display = 'none';
@@ -837,6 +844,7 @@
 </tr>
 </table>
 </div>
+<div id='score_chart' style='width:100%;height:400px;display:none'></div>
 {% endblock %}
 
 {% block back_notice %}

--- a/templates/llnewunitsis.html
+++ b/templates/llnewunitsis.html
@@ -8,6 +8,7 @@
    <script type="text/javascript" src="{{ url_for('static', filename='twintailosu.js') }}?v=1.01"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='llsong.js') }}"></script>
    <script type="text/javascript" src="{{ url_for('static', filename='lldata.js') }}"></script>
+   <script type="text/javascript" src="/static/js/highcharts/highcharts.js"></script>
    <link rel="shortcut icon" href="/static/shortcuticon.png" />
    <style type="text/css">
    	img {height:65px;width:65px}
@@ -25,6 +26,7 @@
    var comp_cardselector = 0;
    var comp_gemstock = 0;
    var comp_resultmic = 0;
+   var comp_distribution_chart = 0;
    $.when(LLCardData.getAllBriefData(), LLSongData.getAllBriefData(), defer_onload).then(function (cardData, songData) {
       // init components
       llsong = new LLSong(songData);
@@ -444,6 +446,11 @@
          document.getElementById('simresult0').innerHTML = llteam.maxScore;
          document.getElementById('simresult100').innerHTML = llteam.minScore;
          document.getElementById('distributionresult').style.display = '';
+         if (!comp_distribution_chart) {
+            comp_distribution_chart = new LLScoreDistributionChart('score_chart', [llteam.naivePercentile]);
+         } else {
+            comp_distribution_chart.addSeries(llteam.naivePercentile);
+         }
       } else {
          document.getElementById('averagescore').innerHTML = llteam.averageScore;
          document.getElementById('distributionresult').style.display = 'none';
@@ -943,6 +950,7 @@
 </tr>
 </table>
 </div>
+<div id='score_chart' style='width:100%;height:400px;display:none'></div>
 {% endblock %}
 
 {% block back_notice %}


### PR DESCRIPTION
Implement issue: ben1222/LLhelper/issues/52 (Add chart for score distribution)

New feature:
* Add score distribution chart to `llnewunit`, `llnewunitsis`, `llnewautounit`: each time calculate with `计算分布` checked, it will add a series to the chart.
![pr55-](https://user-images.githubusercontent.com/17180510/49695806-3cb98180-fbdb-11e8-9651-86d9a6da27af.png)
