### PR TITLE
add message when failed to load notes in llcoverage

### DIFF
--- a/static/CoverageCalculator.js
+++ b/static/CoverageCalculator.js
@@ -1291,6 +1291,7 @@ function CoverageCalculator(song, difficulty, createdData)
         labelsstep = null;
     }
     document.getElementById('running').style.display = "";
+    document.getElementById('running').innerHTML = "运行中…";
     document.getElementById("running").scrollIntoView();
     Map = new Array(0);
 
@@ -1298,6 +1299,7 @@ function CoverageCalculator(song, difficulty, createdData)
         CoverageCalculatorWithData(song, member, member_C, _offset, s, createdData);
     } else {
         var maps = song[difficulty].liveid;
+        var jsonPath = song[difficulty].jsonpath;
         var _liveid = Number(maps);
         //处理文件序号
         var j = maps.length;
@@ -1313,8 +1315,19 @@ function CoverageCalculator(song, difficulty, createdData)
         {
             maps = "https://rawfile.loveliv.es/livejson/Live_s" + maps + ".json";
         }
-        $.getJSON(maps, function (data) {
+        var calcFunc = function (data) {
            CoverageCalculatorWithData(song, member, member_C, _offset, s, data);
+        };
+        var failFunc = function () {
+           console.error("Failed to get json for live id " + _liveid);
+           document.getElementById('running').innerHTML = "谱面下载失败";
+        };
+        $.getJSON(maps, calcFunc).fail(function () {
+           if (jsonPath) {
+              $.getJSON("https://rawfile.loveliv.es/livejson/" + jsonPath, calcFunc).fail(failFunc);
+           } else {
+              failFunc();
+           }
         });
     }
 }

--- a/templates/llcoverage.html
+++ b/templates/llcoverage.html
@@ -22,6 +22,7 @@
 {% block script %}
    <script>
    LLSongData.briefKeys.push('bpm');
+   LLSongData.briefKeys.push('jsonpath');
    var llsong = 0;
    var mezame = 0;
    var language = 0;
@@ -622,7 +623,7 @@
 </div>
 <div style="clear:both">
 </div>
-<div id="running" style="display:none;background:#ffffb0;width:550px;text-align:center"><b>运行中…</b></div>
+<div id="running" style="display:none;background:#ffffb0;width:550px;text-align:center;font-weight:bold">运行中…</div>
 {% endblock %}
 
 {% block back_notice %}

--- a/updatenewlive.py
+++ b/updatenewlive.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
 			diff['bscore'] = livetmp[6]
 			diff['ascore'] = livetmp[7]
 			diff['sscore'] = livetmp[8]
-			jsonpath = livetmp[4]
+			diff['jsonpath'] = livetmp[4]
 			song['attribute'] = attribute[livetmp[3]]
 			livetmp = livesetting.fetchone()
 


### PR DESCRIPTION
New feature:
* Add message when failed to load notes in `llcoverage`
![pr56-](https://user-images.githubusercontent.com/17180510/51440354-3ef61c00-1d01-11e9-8ff6-443b472cf5af.png)

Developer enhancement:
* Add `jsonpath` in songdata when `updatenewlive.py`
