### PR TITLE
fix simulate not considering tap score up buff

### DIFF
--- a/static/lldata.js
+++ b/static/lldata.js
@@ -2132,6 +2132,7 @@ var LLSimulateContext = (function() {
       this.totalTime = maxTime;
       this.totalPerfect = mapdata.perfect;
       this.mapSkillPossibilityUp = (1 + parseInt(mapdata.skillup || 0)/100);
+      this.mapTapScoreUp = (1 + parseInt(mapdata.tapup || 0)/100);
       this.currentTime = 0;
       this.currentNote = 0;
       this.currentCombo = 0;
@@ -2865,7 +2866,7 @@ var LLTeam = (function() {
                   //}
                   var baseAttribute = this.finalAttr[mapdata.attribute] + env.effects[LLConst.SKILL_EFFECT_ATTRIBUTE_UP];
                   // note position 数值1~9, 从右往左数
-                  var baseNoteScore = Math.ceil(baseAttribute/100 * curNote.factor * accuracyBonus * memberBonusFactor[9-curNote.note.position] * LLConst.getComboScoreFactor(env.currentCombo));
+                  var baseNoteScore = Math.ceil(baseAttribute/100 * curNote.factor * accuracyBonus * memberBonusFactor[9-curNote.note.position] * LLConst.getComboScoreFactor(env.currentCombo) * env.mapTapScoreUp);
                   env.currentScore += baseNoteScore + comboFeverScore + perfectScoreUp;
                   env.totalPerfectScoreUp += perfectScoreUp;
                }

--- a/static/siteversion.js
+++ b/static/siteversion.js
@@ -3,11 +3,11 @@
  */
 
 var LLSiteVersion = (function(){
-   var current_version = 20190320;
+   var current_version = 20190327;
    var VISITED_VERSION_KEY = 'llhelper_visited_version__';
 
    function getVisitedVersion() {
-      var version = 0;
+      var version = current_version;
       try {
          version = parseInt(localStorage.getItem(VISITED_VERSION_KEY) || 0);
       } catch (e) {

--- a/templates/releasenotes.html
+++ b/templates/releasenotes.html
@@ -20,6 +20,13 @@
          var update_history = [
             {
                'version': LLSiteVersion.current_version,
+               'fixes': [
+                  '修复了模拟计算没有把点击得分加成纳入计算的问题',
+                  '部分浏览器不支持本地本地存储, 为了防止强迫症发作, 不在此类浏览器上显示近期更新旁边的"1"'
+               ]
+            },
+            {
+               'version': 20190320,
                'features': [
                   '增加近期更新页面',
                   [


### PR DESCRIPTION
Bug fixes:
* Fix the issue that tap score up buff didn't affact simulation
![PR62-模拟计算点击得分加成](https://user-images.githubusercontent.com/17180510/55083909-40680a00-50df-11e9-8a67-78535c702be0.png)
* Do not show new message when browser not support localstorage
