### PR TITLE
support updated skill level boost

### DIFF
--- a/static/lldata.js
+++ b/static/lldata.js
@@ -827,8 +827,10 @@ var LLConst = (function () {
       else if (combo <= 800) return 1.3;
       else return 1.35;
    };
-   ret.getComboFeverBonus = function(combo) {
-      return (combo >= 300 ? 10 : Math.pow(Math.floor(combo/10), 2)/100+1);
+   var COMBO_FEVER_PATTERN_2 = [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2, 2.25, 2.5, 2.75, 3, 3.5, 4, 5, 6, 7, 8, 9, 10]
+   ret.getComboFeverBonus = function(combo, pattern) {
+      if (pattern == 1) return (combo >= 300 ? 10 : Math.pow(Math.floor(combo/10), 2)/100+1);
+      return (combo >= 220 ? 10 : COMBO_FEVER_PATTERN_2[Math.floor(combo/10)]);
    };
    return ret;
 })();
@@ -1192,14 +1194,15 @@ var LLSkillContainer = (function() {
       LLComponentCollection.call(this);
       this.skillLevel = 0; // base 0, range 0-7
       this.cardData = undefined;
-      options = options || {
-         container: 'skillcontainer',
-         lvup: 'skilllvup',
-         lvdown: 'skilllvdown',
-         level: 'skilllevel',
-         text: 'skilltext'
-      };
+      options = options || {};
+      options.container = options.container || 'skillcontainer';
+      options.lvup = options.lvup || 'skilllvup';
+      options.lvdown = options.lvdown || 'skilllvdown';
+      options.level = options.level || 'skilllevel';
+      options.text = options.text || 'skilltext';
+      options.showall = options.showall || 0;
       var me = this;
+      this.showAll = (options.showall || 0);
       this.add('container', new LLComponentBase(options.container));
       this.add('lvup', new LLComponentBase(options.lvup));
       this.getComponent('lvup').on('click', function (e) {
@@ -1220,10 +1223,14 @@ var LLSkillContainer = (function() {
    var proto = cls.prototype;
    proto.setSkillLevel = function (lv) {
       if (lv == this.skillLevel) return;
-      if (lv > 7) {
+      var lvCap = 8;
+      if (this.showAll && this.cardData && this.cardData.skilldetail && this.cardData.skilldetail.length > lvCap) {
+         lvCap = this.cardData.skilldetail.length;
+      }
+      if (lv >= lvCap) {
          this.skillLevel = 0;
       } else if (lv < 0) {
-         this.skillLevel = 7;
+         this.skillLevel = lvCap-1;
       } else {
          this.skillLevel = lv;
       }
@@ -2108,7 +2115,7 @@ var LLMember = (function() {
          return this.card.skilldetail[this.skilllevel-1];
       }
       var lv = this.skilllevel + levelBoost;
-      if (lv > 8) lv = 8;
+      if (lv > this.card.skilldetail.length) lv = this.card.skilldetail.length;
       return this.card.skilldetail[lv-1];
    };
    return cls;
@@ -2140,6 +2147,7 @@ var LLSimulateContext = (function() {
       this.totalPerfect = mapdata.perfect;
       this.mapSkillPossibilityUp = (1 + parseInt(mapdata.skillup || 0)/100);
       this.mapTapScoreUp = (1 + parseInt(mapdata.tapup || 0)/100);
+      this.comboFeverPattern = parseInt(mapdata.combo_fever_pattern || 2);
       this.currentTime = 0;
       this.currentNote = 0;
       this.currentCombo = 0;
@@ -2878,7 +2886,7 @@ var LLTeam = (function() {
                      accuracyBonus *= LLConst.NOTE_WEIGHT_PERFECT_FACTOR;
                   }
                   if (env.effects[LLConst.SKILL_EFFECT_COMBO_FEVER] > 0) {
-                     comboFeverScore = Math.ceil(LLConst.getComboFeverBonus(env.currentCombo) * env.effects[LLConst.SKILL_EFFECT_COMBO_FEVER]);
+                     comboFeverScore = Math.ceil(LLConst.getComboFeverBonus(env.currentCombo, env.comboFeverPattern) * env.effects[LLConst.SKILL_EFFECT_COMBO_FEVER]);
                      if (comboFeverScore > LLConst.SKILL_LIMIT_COMBO_FEVER) {
                         comboFeverScore = LLConst.SKILL_LIMIT_COMBO_FEVER;
                      }
@@ -4396,6 +4404,10 @@ var LLScoreDistributionParameter = (function () {
       {'value': '9', 'text': '9速'},
       {'value': '10', 'text': '10速'}
    ];
+   var comboFeverPatternSelectOptions = [
+      {'value': '1', 'text': '技能加强前（300 combo达到最大加成）'},
+      {'value': '2', 'text': '技能加强后（220 combo达到最大加成）'}
+   ];
    var distTypeDetail = [
       ['#要素', '#计算理论分布/计算技能强度', '#计算模拟分布'],
       ['触发条件: 时间, 图标, 连击, perfect, star perfect, 分数', '支持', '支持'],
@@ -4427,6 +4439,9 @@ var LLScoreDistributionParameter = (function () {
       var simParamSpeedComponent = new LLSelectComponent(createElement('select', {'className': 'form-control', 'value': '8'}));
       simParamSpeedComponent.setOptions(speedSelectOptions);
       simParamSpeedComponent.set('8');
+      var simParamComboFeverPatternComponent = new LLSelectComponent(createElement('select', {'className': 'form-control'}));
+      simParamComboFeverPatternComponent.setOptions(comboFeverPatternSelectOptions);
+      simParamComboFeverPatternComponent.set('2');
       var simParamContainer = createElement('div', {'className': 'form-inline'}, [
          createElement('div', {'className': 'form-group'}, [
             createElement('label', {'innerHTML': '模拟次数：'}),
@@ -4444,6 +4459,11 @@ var LLScoreDistributionParameter = (function () {
             createElement('label', {'innerHTML': '速度：'}),
             simParamSpeedComponent.element,
             createElement('span', {'innerHTML': '（图标下落速度，1速最慢，10速最快）'})
+         ]),
+         createElement('br'),
+         createElement('div', {'className': 'form-group'}, [
+            createElement('label', {'innerHTML': 'Combo Fever技能：'}),
+            simParamComboFeverPatternComponent.element
          ]),
          createElement('br'),
          createElement('span', {'innerHTML': '注意：默认曲目的模拟分布与理论分布不兼容，两者计算结果可能会有较大差异，如有需要请选默认曲目2'})
@@ -4476,7 +4496,8 @@ var LLScoreDistributionParameter = (function () {
             'type': selComp.get(),
             'count': simParamCount.value,
             'perfect_percent': simParamPerfectPercent.value,
-            'speed': simParamSpeedComponent.get()
+            'speed': simParamSpeedComponent.get(),
+            'combo_fever_pattern': simParamComboFeverPatternComponent.get()
          }
       };
       controller.setParameters = function (data) {
@@ -4485,6 +4506,7 @@ var LLScoreDistributionParameter = (function () {
          if (data.count !== undefined) simParamCount.value = data.count;
          if (data.perfect_percent !== undefined) simParamPerfectPercent.value = data.perfect_percent;
          if (data.speed) simParamSpeedComponent.set(data.speed);
+         if (data.combo_fever_pattern) simParamComboFeverPatternComponent.set(data.combo_fever_pattern);
       };
       return container;
    }

--- a/static/siteversion.js
+++ b/static/siteversion.js
@@ -3,7 +3,7 @@
  */
 
 var LLSiteVersion = (function(){
-   var current_version = 20190406;
+   var current_version = 20190415;
    var VISITED_VERSION_KEY = 'llhelper_visited_version__';
 
    function getVisitedVersion() {

--- a/templates/llnewcarddata.html
+++ b/templates/llnewcarddata.html
@@ -53,13 +53,14 @@
    LLCardData.briefKeys.push('minslot', 'maxslot', 'smile2', 'pure2', 'cool2');
    $.when(LLCardData.getAllBriefData(), defer_onload).then(function (cardData) {
       // init 2 skill containers
-      comp_skill = new LLSkillContainer();
+      comp_skill = new LLSkillContainer({'showall': 1});
       comp_skill2 = new LLSkillContainer({
-         container: 'skillcontainer2',
-         lvup: 'skilllvup2',
-         lvdown: 'skilllvdown2',
-         level: 'skilllevel2',
-         text: 'skilltext2'
+         'container': 'skillcontainer2',
+         'lvup': 'skilllvup2',
+         'lvdown': 'skilllvdown2',
+         'level': 'skilllevel2',
+         'text': 'skilltext2',
+         'showall': 1
       });
       var origSetSkillLevel = comp_skill.setSkillLevel;
       var newSetSkillLevel = function (lv) {

--- a/templates/llnewunit.html
+++ b/templates/llnewunit.html
@@ -362,6 +362,7 @@
          } else if (distParam.type == 'sim') {
             llmap.perfect = Math.floor(parseFloat(distParam.perfect_percent || 0)/100 * llmap.combo);
             llmap.speed = distParam.speed;
+            llmap.combo_fever_pattern = distParam.combo_fever_pattern;
             err = llteam.simulateScoreDistribution(llmap, extraData[0], parseInt(distParam.count));
          } else {
             err = '未知的得分分布';
@@ -447,15 +448,17 @@
 {% block front_notice %}
 <h4 class="alert-heading">使用方法</h4>
 <ol>
-      <li>选择歌曲 或 填写歌曲详细信息 <font style='color:red'><b>务必记得修改perfect数量</b></font></li>
-      <li>从卡牌库中选择一张卡，点击转移来放置到对应位置，没有录入的卡片数据可以手动输入 <font style='color:red'><b>一张卡默认为满级、一级技能的数据，若不是则需要修改</b></font></li>
+      <li>选择歌曲 或 填写歌曲详细信息 <font style='color:red'><b>务必记得修改perfect数量（若卡组中有判卡，请填写带判情况下的perfect数量）</b></font></li>
+      <li>选择卡牌数据版本</li>
+      <li>从卡牌库中选择一张卡，点击「放卡」来放置到对应位置 <font style='color:red'><b>一张卡默认为满级、一级技能的数据，若不是则需要修改</b></font></li>
       <li>使用以上方法选择所有的9张卡</li>
-      <li>可以点击「保存队伍」将队伍配置文件保存到本地</li>
-      <li>第2、3步可以从保存的文件中读取队伍信息来代替：点击「选择文件」选择本地配置文件，再点击「读取队伍」</li>
-      <li>选择主唱技能和好友主唱技能 <font style='color:red'><b>计算SM得分时将好友主唱加成设为0%</b></font></li>
-      <li>点击Calculate</li>
+      <li>可以点击「保存队伍」将队伍配置文件保存到本地，也可以在「队伍列表」中保存到浏览器</li>
+      <li>第3、4步可以从保存的文件中读取队伍信息来代替：点击「选择文件」选择本地配置文件，再点击「读取队伍」；或点击「队伍列表」中的队伍名称</li>
+      <li>选择主唱技能和好友主唱技能，设置点击得分增加系数和技能发动率增加系数 <font style='color:red'><b>计算SM、MF、CF、协力得分时将好友主唱加成设为0%</b></font></li>
+      <li>选择分数分布计算模式。目前有3种计算模式，分别为「不计算分布」、「计算理论分布」和「计算模拟分布」。「不计算分布」和「计算理论分布」不支持 <font style='color:red'><b>box新技能的计算</b></font>；「计算模拟分布」 <font style='color:red'><b>支持大部分box新技能的计算</b></font>，若选择该项需要设置模拟次数、 <font style='color:red'><b>无判perfect率</b></font>和图标下落速度， <font style='color:red'><b>如果要计算默认歌曲请选择默认曲目2</b></font>（各模式支持计算的技能/宝石列表请点击「查看支持计算的技能/宝石」）</li>
+      <li>点击calculate进行计算。「不计算分布」仅会显示期望得分；「计算理论分布」会显示期望得分和理论得分分布；「计算模拟分布」会进行模拟打歌，将模拟结果汇总绘制成曲线，如果要清空图中内容请点击「清空曲线」</li>
 </ol>
-<p>当前版本：4.1及以上。</p>
+<p>当前版本：6.5.3。</p>
 {% endblock %}
 
 {% block main %}
@@ -882,18 +885,17 @@
 {% block back_notice %}
 <h4 class="alert-heading">注意</h4>
 <ul>
-   <li>勾选「计算分布」来计算得分分布。得分分布使用真实分布计算，计算速度比较慢。</li>
-   <li>由于使用歌曲信息计算，最终结果可能会有千分之一的误差</li>
-   <li>判定覆盖率仅供参考</li>
-   <li>判定期间属性1.25倍的宝石计算有误，暂时按无效计算。</li>
-   <li>日服新宝石的计算正在测试中，可能有计算错误，欢迎反馈</li>
+   <li>「计算理论分布」使用真实分布计算，计算速度比较慢；「计算模拟分布」使用模拟打歌计算，模拟次数越多，计算速度越慢，但也越接近真实分布</li>
+   <li>由于使用歌曲信息计算，最终结果可能会有误差</li>
+   <li>判定期间属性1.33倍的宝石计算有误，暂时按无效计算。</li>
+   <li>由于「不计算分布」和「计算理论分布」不支持box新技能的计算，新技能卡的技能强度会显示为0</li>
+   <li>默认曲目的模拟分布与理论分布不兼容，两者计算结果可能会有较大差异</li>
 </ul>
 {% endblock %}
 
 {% block back_notice_2 %}
 <h4 class="alert-heading">说明</h4>
 <ul>
-   <li>在卡片数据行中的判定指的该卡片的边际判定覆盖率影响，即撤掉这张卡后边际覆盖率的损失。在括号中的覆盖率为单卡判定覆盖率</li>
    <li>卡强度指的是不考虑异色和异团带来的负面影响时的强度，该数值方便异团卡、异色横向比较。实际强度则是考虑异色和异团加成的强度</li>
 </ul>
 {% endblock %}

--- a/templates/releasenotes.html
+++ b/templates/releasenotes.html
@@ -21,6 +21,17 @@
             {
                'version': LLSiteVersion.current_version,
                'features': [
+                  '模拟计算可以计算加强后的 技能等级提升 的卡了',
+                  '模拟计算中增加了选择combo fever技能版本的选项，加强前版本适用于目前的国服，加强后版本适用于日服',
+                  '在#llnewcarddata#页面可以查看超过8级的技能的数值了（卡牌数据须选择日服版本）'
+               ],
+               'enhancements': [
+                  '更新了#llnewunit#页面的使用说明和注意事项'
+               ]
+            },
+            {
+               'version': 20190406,
+               'features': [
                   '在#llnewunit#,#llnewunitsis#,#llnewautounit#页面增加得清空得分分布曲线的按钮'
                ]
             },

--- a/updatenewcard.py
+++ b/updatenewcard.py
@@ -124,13 +124,16 @@ if __name__ == "__main__":
             # skill detailed effect for each level
             skilldetail = jpdbconn.execute('SELECT effect_value,discharge_time,trigger_value,activation_rate FROM unit_skill_level_m WHERE unit_skill_id = '+str(skillid)+' ORDER BY skill_level ASC;')
             card['skilldetail'] = []
-            for i in range(0, 8):
-                tmp = skilldetail.fetchone()
+            tmp = skilldetail.fetchone()
+            i = 0
+            while tmp:
                 card['skilldetail'].append({})
                 card['skilldetail'][i]['score'] = tmp[0]
                 card['skilldetail'][i]['time'] = tmp[1]
                 card['skilldetail'][i]['require'] = tmp[2]
                 card['skilldetail'][i]['possibility'] = tmp[3]
+                i = i + 1
+                tmp = skilldetail.fetchone()
             triggertarget = jpdbconn.execute('SELECT trigger_target FROM unit_skill_trigger_target_m WHERE unit_skill_id = '+str(skillid)+' ORDER BY trigger_target DESC;')
             tmp = triggertarget.fetchone()
             if tmp:

--- a/updatenewlive.py
+++ b/updatenewlive.py
@@ -30,9 +30,8 @@ live_setting_query_str = (
 ' live_setting_m.a_rank_score,'
 ' live_setting_m.s_rank_score,'
 ' live_setting_m.s_rank_combo,'
-' CASE WHEN special_live_m.ac_flag IS NOT NULL THEN 1 ELSE 0 END as is_ac '
+' live_setting_m.ac_flag as is_ac '
 'FROM live_setting_m '
-'LEFT JOIN special_live_m ON special_live_m.live_setting_id = live_setting_m.live_setting_id AND special_live_m.ac_flag = 1 '
 'WHERE live_track_id = %s;'
 )
 


### PR DESCRIPTION
Features:
* Support updated skill level boost skill in simulation
![PR65-技能等级提升加强测试](https://user-images.githubusercontent.com/17180510/56145526-0780ce00-5fd7-11e9-9233-6f89c1fc9df6.png)
![PR65-技能等级提升加强测试2](https://user-images.githubusercontent.com/17180510/56145535-0c458200-5fd7-11e9-90eb-4b7e92bada70.png)
* Added a selection for combo fever patter in simulation
![PR65-CF分版本](https://user-images.githubusercontent.com/17180510/56145736-6ba39200-5fd7-11e9-8a86-2f75bb6b4085.png)
![PR65-CF分暗改](https://user-images.githubusercontent.com/17180510/56145575-21221580-5fd7-11e9-9e5e-2f6badd0f30d.png)
* In `llnewcarddata`  page, show skill level over 8:
![PR65-卡片数据查询超过8级](https://user-images.githubusercontent.com/17180510/56145978-fab0aa00-5fd7-11e9-8460-1ad02c456539.png)

Enhancements:
* Updated `llnewunit` usage text

Fixes:
* Fixed song update script (ac flag was moved from `special_live_m` to `live_setting_m`

